### PR TITLE
Add state file path to Terraform plan command

### DIFF
--- a/lib/terraform/command_factory.rb
+++ b/lib/terraform/command_factory.rb
@@ -96,6 +96,7 @@ module Terraform
       options.input = false
       options.out = config[:plan]
       options.parallelism = config[:parallelism]
+      options.state = config[:state]
       options.var = config[:variables]
       options.var_file = config[:variable_files]
     end

--- a/lib/terraform/command_factory.rb
+++ b/lib/terraform/command_factory.rb
@@ -40,7 +40,6 @@ module Terraform
         .new target: config[:directory] do |options|
           configure_plan options: options
           options.destroy = true
-          options.state = config[:state]
         end
     end
 


### PR DESCRIPTION
This is untested, but I think https://github.com/newcontext-oss/kitchen-terraform/issues/102 is being caused by the `plan` command not configuring the appropriate state file path.