### PR TITLE
Reduce shell outs

### DIFF
--- a/lib/kitchen/verifier/terraform/configure_inspec_runner_attributes.rb
+++ b/lib/kitchen/verifier/terraform/configure_inspec_runner_attributes.rb
@@ -21,9 +21,9 @@ module Kitchen
     class Terraform < ::Kitchen::Verifier::Inspec
       ConfigureInspecRunnerAttributes = lambda do |client:, config:, group:, terraform_state:|
         {"terraform_state" => terraform_state}.tap do |attributes|
-          client.each_output_name do |output_name| attributes.store output_name, client.output(name: output_name) end
+          client.output.each do |name, value| attributes.store name, value end
           group.fetch(:attributes, {}).each_pair do |attribute_name, output_name|
-            attributes.store attribute_name.to_s, client.output(name: output_name)
+            attributes.store attribute_name.to_s, attributes[output_name]
           end
           config.store :attributes, attributes
         end

--- a/lib/kitchen/verifier/terraform/enumerate_group_hosts.rb
+++ b/lib/kitchen/verifier/terraform/enumerate_group_hosts.rb
@@ -18,7 +18,9 @@ require "kitchen/verifier/terraform"
 
 ::Kitchen::Verifier::Terraform::EnumerateGroupHosts = lambda do |client:, group:, &block|
   if group.key? :hostnames
-    client.iterate_output name: group.fetch(:hostnames) do |hostname| block.call host: hostname end
+    client.output_search(name: group.fetch(:hostnames)).each do |hostname|
+      block.call host: hostname
+    end
   else
     block.call host: "localhost"
   end

--- a/lib/terraform/client.rb
+++ b/lib/terraform/client.rb
@@ -40,14 +40,12 @@ module Terraform
       output_search_parser(name: name).parsed_output
     end
 
-    def output()
-      output_parser().parsed_output
+    def output
+      output_parser.parsed_output
     end
 
     def version
-      @version ||= execute command: factory.version_command do |value|
-        execute command: factory.version_command do |value| return value.slice /v(\d+\.\d+\.\d+)/, 1 end
-      end
+      @version ||= execute command: factory.version_command do |value| return value.slice /v(\d+\.\d+\.\d+)/, 1 end
     end
 
     private
@@ -82,7 +80,7 @@ module Terraform
       ::Terraform::NoOutputSearchParser.new
     end
 
-    def output_parser()
+    def output_parser
       execute command: factory.output_command(target: "") do |value|
         return ::Terraform::OutputParser.new output: value
       end

--- a/lib/terraform/no_output_parser.rb
+++ b/lib/terraform/no_output_parser.rb
@@ -17,12 +17,8 @@
 module Terraform
   # A null parser for when there are no outputs defined
   class NoOutputParser
-    def each_name; end
-
-    def iterate_parsed_output; end
-
     def parsed_output
-      ""
+      {}
     end
   end
 end

--- a/lib/terraform/no_output_search_parser.rb
+++ b/lib/terraform/no_output_search_parser.rb
@@ -14,15 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-::RSpec.shared_context "::Kitchen::Verifier::Terraform::ConfigureInspecRunnerAttributes.call" do
-  before do
-    allow(client).to receive(:output).with(no_args).and_return(
-        "output_name_one" => "output_value_one",
-        "output_name_two" => "output_value_two"
-    )
-
-    allow(client).to receive(:output_search).with(name: "output_name_one").and_return "output_value_one"
-
-    allow(client).to receive(:output_search).with(name: "output_name_two").and_return "output_value_two"
+module Terraform
+  # A null parser for when there are no outputs defined
+  class NoOutputSearchParser
+    def parsed_output
+      ""
+    end
   end
 end

--- a/lib/terraform/output_parser.rb
+++ b/lib/terraform/output_parser.rb
@@ -19,16 +19,10 @@ require "json"
 module Terraform
   # A parser for output command values
   class OutputParser
-    def each_name(&block)
-      json_output.each_key &block
-    end
-
-    def iterate_parsed_output(&block)
-      Array(parsed_output).each &block
-    end
-
     def parsed_output
-      json_output.fetch "value"
+      out = json_output
+      out.dup.each { |key, value| out[key] = value["value"] }
+      out
     end
 
     private

--- a/lib/terraform/output_search_parser.rb
+++ b/lib/terraform/output_search_parser.rb
@@ -14,15 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-::RSpec.shared_context "::Kitchen::Verifier::Terraform::ConfigureInspecRunnerAttributes.call" do
-  before do
-    allow(client).to receive(:output).with(no_args).and_return(
-        "output_name_one" => "output_value_one",
-        "output_name_two" => "output_value_two"
-    )
+require "json"
 
-    allow(client).to receive(:output_search).with(name: "output_name_one").and_return "output_value_one"
+module Terraform
+  # A parser for output command values
+  class OutputSearchParser
+    def parsed_output
+      json_output["value"]
+    end
 
-    allow(client).to receive(:output_search).with(name: "output_name_two").and_return "output_value_two"
+    private
+
+    attr_accessor :output
+
+    def initialize(output:)
+      self.output = output
+    end
+
+    def json_output
+      ::JSON.parse output
+    end
   end
 end

--- a/spec/lib/kitchen/verifier/terraform/enumerate_group_hosts_spec.rb
+++ b/spec/lib/kitchen/verifier/terraform/enumerate_group_hosts_spec.rb
@@ -34,7 +34,7 @@ require "kitchen/verifier/terraform/enumerate_group_hosts"
       before do
         group.store :hostnames, hostnames
 
-        allow(client).to receive(:iterate_output).with(name: hostnames).and_yield "hostname"
+        allow(client).to receive(:output_search).with(name: hostnames).and_return ["hostname"]
       end
 
       it "yields each resolved hostname" do is_expected.to yield_with_args host: "hostname" end

--- a/spec/lib/terraform/client_spec.rb
+++ b/spec/lib/terraform/client_spec.rb
@@ -98,39 +98,21 @@ require "terraform/client"
     it_behaves_like "#apply"
   end
 
-  describe "#each_output_name" do
-    subject do lambda do |block| described_instance.each_output_name &block end end
+  describe "#output" do
+    subject do described_instance.output end
 
     context "when outputs are defined" do
       include_context "outputs are defined"
 
-      let :output_value do ::JSON.dump "output_name_1" => "output_value_1", "output_name_2" => "output_value_2" end
+      let :output_value do ::JSON.dump "name1" => {"value" => "value1"}, "name2" => {"value" => "value2"} end
 
-      it "yields each output name" do is_expected.to yield_successive_args "output_name_1", "output_name_2" end
+      it "returns the hash" do is_expected.to eq("name1" => "value1", "name2" => "value2")  end
     end
 
     context "when outputs are not defined" do
       include_context "outputs are not defined"
 
-      it "does not yield" do is_expected.to_not yield_control end
-    end
-  end
-
-  describe "#iterate_output" do
-    subject do lambda do |block| described_instance.iterate_output name: "name", &block end end
-
-    context "when outputs are defined" do
-      include_context "outputs are defined"
-
-      let :output_value do ::JSON.dump "value" => ["value1", "value2"] end
-
-      it "iterates the output values" do is_expected.to yield_successive_args "value1", "value2" end
-    end
-
-    context "when outputs are not defined" do
-      include_context "outputs are not defined"
-
-      it "does not yield" do is_expected.to_not yield_control end
+      it "returns empty hash" do is_expected.to eq({}) end
     end
   end
 
@@ -154,8 +136,8 @@ require "terraform/client"
     end
   end
 
-  describe "#output" do
-    subject do described_instance.output name: "name" end
+  describe "#output_search" do
+    subject do described_instance.output_search name: "name" end
 
     context "when outputs are defined" do
       include_context "outputs are defined"
@@ -168,7 +150,7 @@ require "terraform/client"
     context "when outputs are not defined" do
       include_context "outputs are not defined"
 
-      it "returns an empty string" do is_expected.to eq "" end
+      it "returns an empty string" do is_expected.to eq("") end
     end
   end
 

--- a/spec/lib/terraform/client_spec.rb
+++ b/spec/lib/terraform/client_spec.rb
@@ -106,7 +106,7 @@ require "terraform/client"
 
       let :output_value do ::JSON.dump "name1" => {"value" => "value1"}, "name2" => {"value" => "value2"} end
 
-      it "returns the hash" do is_expected.to eq("name1" => "value1", "name2" => "value2")  end
+      it "returns the hash" do is_expected.to eq("name1" => "value1", "name2" => "value2") end
     end
 
     context "when outputs are not defined" do

--- a/spec/lib/terraform/no_output_parser_spec.rb
+++ b/spec/lib/terraform/no_output_parser_spec.rb
@@ -19,21 +19,9 @@ require "terraform/no_output_parser"
 ::RSpec.describe ::Terraform::NoOutputParser do
   let :described_instance do described_class.new end
 
-  describe "#each_name" do
-    subject do lambda do |block| described_instance.each_name &block end end
-
-    it "does not yield" do is_expected.to_not yield_control end
-  end
-
-  describe "#iterate_parsed_output" do
-    subject do lambda do |block| described_instance.iterate_parsed_output &block end end
-
-    it "does not yield" do is_expected.to_not yield_control end
-  end
-
   describe "#parsed_output" do
     subject do described_instance.parsed_output end
 
-    it "returns an empty string" do is_expected.to eq "" end
+    it "returns an empty hash" do is_expected.to eq({}) end
   end
 end

--- a/spec/lib/terraform/no_output_search_parser_spec.rb
+++ b/spec/lib/terraform/no_output_search_parser_spec.rb
@@ -14,15 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-::RSpec.shared_context "::Kitchen::Verifier::Terraform::ConfigureInspecRunnerAttributes.call" do
-  before do
-    allow(client).to receive(:output).with(no_args).and_return(
-        "output_name_one" => "output_value_one",
-        "output_name_two" => "output_value_two"
-    )
+require "terraform/no_output_search_parser"
 
-    allow(client).to receive(:output_search).with(name: "output_name_one").and_return "output_value_one"
+::RSpec.describe ::Terraform::NoOutputSearchParser do
+  let :described_instance do described_class.new end
 
-    allow(client).to receive(:output_search).with(name: "output_name_two").and_return "output_value_two"
+  describe "#parsed_output" do
+    subject do described_instance.parsed_output end
+
+    it "returns an empty string" do is_expected.to eq "" end
   end
 end

--- a/spec/lib/terraform/output_parser_spec.rb
+++ b/spec/lib/terraform/output_parser_spec.rb
@@ -19,7 +19,7 @@ require "terraform/output_parser"
 ::RSpec.describe ::Terraform::OutputParser do
   let :described_instance do described_class.new output: output end
 
-  describe '#parsed_output' do
+  describe "#parsed_output" do
     let :output do
       ::JSON.dump "output_name_1" => {"value" => "output_value_1"},
                   "output_name_2" => {"value" => "output_value_2"}
@@ -27,10 +27,9 @@ require "terraform/output_parser"
 
     subject do described_instance.parsed_output end
 
-    it 'returns each output name' do
+    it "returns each output name" do
       is_expected.to eq "output_name_1" => "output_value_1",
                         "output_name_2" => "output_value_2"
-
     end
   end
 end

--- a/spec/lib/terraform/output_parser_spec.rb
+++ b/spec/lib/terraform/output_parser_spec.rb
@@ -19,27 +19,18 @@ require "terraform/output_parser"
 ::RSpec.describe ::Terraform::OutputParser do
   let :described_instance do described_class.new output: output end
 
-  describe "#each_name" do
-    let :output do ::JSON.dump "output_name_1" => "output_value_1", "output_name_2" => "output_value_2" end
-
-    subject do lambda do |block| described_instance.each_name &block end end
-
-    it "yields each output name" do is_expected.to yield_successive_args "output_name_1", "output_name_2" end
-  end
-
-  describe "#iterate_parsed_output" do
-    let :output do ::JSON.dump "value" => ["foo", "bar"] end
-
-    subject do lambda do |block| described_instance.iterate_parsed_output &block end end
-
-    it "yields each element" do is_expected.to yield_successive_args "foo", "bar" end
-  end
-
-  describe "#parsed_output" do
-    let :output do ::JSON.dump "value" => "foo" end
+  describe '#parsed_output' do
+    let :output do
+      ::JSON.dump "output_name_1" => {"value" => "output_value_1"},
+                  "output_name_2" => {"value" => "output_value_2"}
+    end
 
     subject do described_instance.parsed_output end
 
-    it "returns the value's 'value' field" do is_expected.to eq "foo" end
+    it 'returns each output name' do
+      is_expected.to eq "output_name_1" => "output_value_1",
+                        "output_name_2" => "output_value_2"
+
+    end
   end
 end

--- a/spec/lib/terraform/output_search_parser_spec.rb
+++ b/spec/lib/terraform/output_search_parser_spec.rb
@@ -19,14 +19,14 @@ require "terraform/output_search_parser"
 ::RSpec.describe ::Terraform::OutputSearchParser do
   let :described_instance do described_class.new output: output end
 
-  describe '#parsed_output' do
+  describe "#parsed_output" do
     let :output do
       ::JSON.dump "value" => "output_value_1"
     end
 
     subject do described_instance.parsed_output end
 
-    it 'returns each output name' do
+    it "returns each output name" do
       is_expected.to eq "output_value_1"
     end
   end

--- a/spec/lib/terraform/output_search_parser_spec.rb
+++ b/spec/lib/terraform/output_search_parser_spec.rb
@@ -14,15 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-::RSpec.shared_context "::Kitchen::Verifier::Terraform::ConfigureInspecRunnerAttributes.call" do
-  before do
-    allow(client).to receive(:output).with(no_args).and_return(
-        "output_name_one" => "output_value_one",
-        "output_name_two" => "output_value_two"
-    )
+require "terraform/output_search_parser"
 
-    allow(client).to receive(:output_search).with(name: "output_name_one").and_return "output_value_one"
+::RSpec.describe ::Terraform::OutputSearchParser do
+  let :described_instance do described_class.new output: output end
 
-    allow(client).to receive(:output_search).with(name: "output_name_two").and_return "output_value_two"
+  describe '#parsed_output' do
+    let :output do
+      ::JSON.dump "value" => "output_value_1"
+    end
+
+    subject do described_instance.parsed_output end
+
+    it 'returns each output name' do
+      is_expected.to eq "output_value_1"
+    end
   end
 end

--- a/spec/support/kitchen/verifier/terraform/configure_inspec_runner_attributes_context.rb
+++ b/spec/support/kitchen/verifier/terraform/configure_inspec_runner_attributes_context.rb
@@ -16,10 +16,9 @@
 
 ::RSpec.shared_context "::Kitchen::Verifier::Terraform::ConfigureInspecRunnerAttributes.call" do
   before do
-    allow(client).to receive(:output).with(no_args).and_return(
-        "output_name_one" => "output_value_one",
-        "output_name_two" => "output_value_two"
-    )
+    allow(client).to receive(:output).with(no_args)
+      .and_return "output_name_one" => "output_value_one",
+                  "output_name_two" => "output_value_two"
 
     allow(client).to receive(:output_search).with(name: "output_name_one").and_return "output_value_one"
 


### PR DESCRIPTION
Fixed up a few performance issues I was running into here caused by shelling out. This is more of an issue if you have lot's of outputs in terraform, for me it my test repo it reduced the load time from 40 to 4 seconds.

One thing that we might want to double check is I switched the order of `client.each_output` and `dup.each_pair` here https://github.com/RyanJarv/kitchen-terraform/commit/ceda4ee89ac3f6b27ba1d64f7c8ea13d957f9bf2#diff-8102be38e9d35f6b0851b08d2c7e8ec6R33. I'm not entirely sure I understand what is happening there but I assumed the dup was to avoid iterating over the same keys and doesn't affect anything else.

### Changes
- Avoid looking terraform key's twice. 
- Changes each_output_name to each_output that includes the terraform key value pair, we use this so we can set the value on Terraform::GroupAttributes directly rather then shelling out again later to get this value.
- Cache version to avoid shelling out
- Fix linter warnings
