### PR TITLE
Rename directory to root_module_directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ This project adheres to [Semantic Versioning].
 
 * Remove the verify_plugins configuration attribute from the driver
 
+* Rename the directory configuration attribute of the driver to
+  root_module_directory
+
 * Lock InSpec to 1.44.8 to maintain support for Ruby 2.2
 
 ### Fixed

--- a/examples/aws_provider/.kitchen.yml
+++ b/examples/aws_provider/.kitchen.yml
@@ -1,8 +1,8 @@
 ---
 driver:
   name: "terraform"
-  directory: "test/fixtures/us_east_1"
   parallelism: 4
+  root_module_directory: "test/fixtures/us_east_1"
 provisioner:
   name: "terraform"
 transport:

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -22,10 +22,10 @@ require "kitchen/terraform/client_version_verifier"
 require "kitchen/terraform/config_attribute/backend_configurations"
 require "kitchen/terraform/config_attribute/color"
 require "kitchen/terraform/config_attribute/command_timeout"
-require "kitchen/terraform/config_attribute/directory"
 require "kitchen/terraform/config_attribute/lock_timeout"
 require "kitchen/terraform/config_attribute/parallelism"
 require "kitchen/terraform/config_attribute/plugin_directory"
+require "kitchen/terraform/config_attribute/root_module_directory"
 require "kitchen/terraform/config_attribute/variable_files"
 require "kitchen/terraform/config_attribute/variables"
 require "kitchen/terraform/configurable"
@@ -58,7 +58,7 @@ require "kitchen/terraform/shell_out"
 #     -get-plugins=true \
 #     [-plugin-dir=<plugin_directory>] \
 #     -verify-plugins=true \
-#     <directory>
+#     <root_module_directory>
 #
 # ===== Creating a Test Terraform Workspace
 #
@@ -82,7 +82,7 @@ require "kitchen/terraform/shell_out"
 #     -get-plugins=true \
 #     [-plugin-dir=<plugin_directory>] \
 #     -verify-plugins=true \
-#     <directory>
+#     <root_module_directory>
 #
 # ===== Selecting the Test Terraform Workspace
 #
@@ -100,7 +100,7 @@ require "kitchen/terraform/shell_out"
 #     -refresh=true \
 #     [-var=<variables.first>...] \
 #     [-var-file=<variable_files.first>...] \
-#     <directory>
+#     <root_module_directory>
 #
 # ===== Selecting the Default Terraform Workspace
 #
@@ -136,9 +136,9 @@ require "kitchen/terraform/shell_out"
 #
 # {include:Kitchen::Terraform::ConfigAttribute::CommandTimeout}
 #
-# ==== directory
+# ==== root_module_directory
 #
-# {include:Kitchen::Terraform::ConfigAttribute::Directory}
+# {include:Kitchen::Terraform::ConfigAttribute::RootModuleDirectory}
 #
 # ==== lock_timeout
 #
@@ -184,13 +184,13 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
 
   include ::Kitchen::Terraform::ConfigAttribute::CommandTimeout
 
-  include ::Kitchen::Terraform::ConfigAttribute::Directory
-
   include ::Kitchen::Terraform::ConfigAttribute::LockTimeout
 
   include ::Kitchen::Terraform::ConfigAttribute::Parallelism
 
   include ::Kitchen::Terraform::ConfigAttribute::PluginDirectory
+
+  include ::Kitchen::Terraform::ConfigAttribute::RootModuleDirectory
 
   include ::Kitchen::Terraform::ConfigAttribute::VariableFiles
 
@@ -310,7 +310,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
             "-refresh=true " \
             "#{config_variables_flags} " \
             "#{config_variable_files_flags} " \
-            "#{config_directory}",
+            "#{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )
@@ -320,7 +320,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
   def apply_run_get
     ::Kitchen::Terraform::ShellOut
       .run(
-        command: "get -update #{config_directory}",
+        command: "get -update #{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )
@@ -365,7 +365,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
             "#{config_color_flag} " \
             "#{config_variables_flags} " \
             "#{config_variable_files_flags} " \
-            "#{config_directory}",
+            "#{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )
@@ -389,7 +389,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
             "-get-plugins=true " \
             "#{config_plugin_directory_flag} " \
             "-verify-plugins=true " \
-            "#{config_directory}",
+            "#{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )
@@ -430,7 +430,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
             "-refresh=true " \
             "#{config_variables_flags} " \
             "#{config_variable_files_flags} " \
-            "#{config_directory}",
+            "#{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )
@@ -453,7 +453,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
             "-get-plugins=true " \
             "#{config_plugin_directory_flag} " \
             "-verify-plugins=true " \
-            "#{config_directory}",
+            "#{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )

--- a/lib/kitchen/terraform/config_attribute/root_module_directory.rb
+++ b/lib/kitchen/terraform/config_attribute/root_module_directory.rb
@@ -24,10 +24,10 @@ require "kitchen/terraform/file_path_config_attribute_definer"
 # Type:: {http://www.yaml.org/spec/1.2/spec.html#id2760844 Scalar}
 # Required:: False
 # Default:: The {https://en.wikipedia.org/wiki/Working_directory working directory} of the Test Kitchen process.
-# Example:: <code>directory: /path/to/terraform/module</code>
+# Example:: <code>root_module_directory: /path/to/terraform/root/module/directory</code>
 #
 # @abstract It must be included by a plugin class in order to be used.
-module ::Kitchen::Terraform::ConfigAttribute::Directory
+module ::Kitchen::Terraform::ConfigAttribute::RootModuleDirectory
   # A callback to define the configuration attribute which is invoked when this module is included in a plugin class.
   #
   # @param plugin_class [::Kitchen::Configurable] A plugin class.
@@ -43,13 +43,13 @@ module ::Kitchen::Terraform::ConfigAttribute::Directory
 
   # @return [::Symbol] the symbol corresponding to the attribute.
   def self.to_sym
-    :directory
+    :root_module_directory
   end
 
   extend ::Kitchen::Terraform::ConfigAttributeCacher
 
   # @return [::String] the working directory of the Test Kitchen process.
-  def config_directory_default_value
+  def config_root_module_directory_default_value
     "."
   end
 end

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -24,10 +24,10 @@ require "support/dry/monads/either_matchers"
 require "support/kitchen/terraform/config_attribute/backend_configurations_examples"
 require "support/kitchen/terraform/config_attribute/color_examples"
 require "support/kitchen/terraform/config_attribute/command_timeout_examples"
-require "support/kitchen/terraform/config_attribute/directory_examples"
 require "support/kitchen/terraform/config_attribute/lock_timeout_examples"
 require "support/kitchen/terraform/config_attribute/parallelism_examples"
 require "support/kitchen/terraform/config_attribute/plugin_directory_examples"
+require "support/kitchen/terraform/config_attribute/root_module_directory_examples"
 require "support/kitchen/terraform/config_attribute/variable_files_examples"
 require "support/kitchen/terraform/config_attribute/variables_examples"
 require "support/kitchen/terraform/configurable_examples"
@@ -86,13 +86,13 @@ require "support/kitchen/terraform/configurable_examples"
 
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::Color"
 
-    it_behaves_like "Kitchen::Terraform::ConfigAttribute::Directory"
-
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::LockTimeout"
 
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::Parallelism"
 
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::PluginDirectory"
+
+    it_behaves_like "Kitchen::Terraform::ConfigAttribute::RootModuleDirectory"
 
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::VariableFiles"
 

--- a/spec/support/kitchen/terraform/config_attribute/root_module_directory_examples.rb
+++ b/spec/support/kitchen/terraform/config_attribute/root_module_directory_examples.rb
@@ -17,10 +17,10 @@
 require "support/kitchen/terraform/config_schemas/string_examples"
 
 ::RSpec
-  .shared_examples "Kitchen::Terraform::ConfigAttribute::Directory" do
+  .shared_examples "Kitchen::Terraform::ConfigAttribute::RootModuleDirectory" do
     include_context(
       "Kitchen::Terraform::ConfigSchemas::String",
-      attribute: :directory,
+      attribute: :root_module_directory,
       default_value: "kitchen_root"
     )
   end


### PR DESCRIPTION
This change removes the ambiguity from the configuration attribute that identifies the root module to test.