### PR TITLE
Replace Dry::Monads with exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 * Format of changelog to adhere to Keep a Changelog 1.0.0
 
+* Internal success and failure to be modeled without monads
+
 ## [3.0.0] - 2017-11-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 * All driver and provisioner actions to attempt to select or create a
   Terraform workspace
 
+### Fixed
+
+* Documented supported Terraform version for ClientVersionVerifier
+
 ## [3.0.0] - 2017-11-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 * Internal success and failure to be modeled without monads
 
+* All driver and provisioner actions to attempt to select or create a
+  Terraform workspace
+
 ## [3.0.0] - 2017-11-28
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     kitchen-terraform (3.0.0)
-      dry-monads (~> 0.3)
       dry-types (~> 0.9)
       dry-validation (~> 0.10)
       inspec (>= 0.34.0, <= 1.44.8)
@@ -40,9 +39,6 @@ GEM
       dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
-    dry-monads (0.4.0)
-      dry-core (~> 0.3, >= 0.3.3)
-      dry-equalizer
     dry-types (0.12.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1)
@@ -101,7 +97,7 @@ GEM
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashie (3.5.6)
-    highline (1.7.8)
+    highline (1.7.10)
     htmlentities (4.3.4)
     httpclient (2.8.3)
     inflecto (0.0.2)
@@ -248,12 +244,12 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0, >= 0.6.1)
-    winrm-fs (1.1.0)
+    winrm-fs (1.1.1)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
       winrm (~> 2.0)
-    yard (0.9.10)
+    yard (0.9.12)
 
 PLATFORMS
   ruby

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -62,8 +62,6 @@ require "kitchen/terraform/version.rb"
 
   specification.add_development_dependency "yard", "~> 0.9"
 
-  specification.add_runtime_dependency "dry-monads", "~> 0.3"
-
   specification.add_runtime_dependency "dry-types", "~> 0.9"
 
   specification.add_runtime_dependency "dry-validation", "~> 0.10"

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -254,6 +254,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
               ::Kitchen::Terraform::ShellOut
                 .run(
                   command: "version",
+                  duration: 600,
                   logger: logger
                 )
           )

--- a/lib/kitchen/provisioner/terraform.rb
+++ b/lib/kitchen/provisioner/terraform.rb
@@ -16,6 +16,7 @@
 
 require "kitchen/provisioner"
 require "kitchen/terraform/configurable"
+require "kitchen/terraform/error"
 
 # The provisioner utilizes the driver to apply changes to the Terraform state in order to reach the desired
 # configuration of the root module.
@@ -86,21 +87,17 @@ class ::Kitchen::Provisioner::Terraform < ::Kitchen::Provisioner::Base
   # @param state [::Hash] the mutable instance and provisioner state.
   # @raise [::Kitchen::ActionFailed] if the result of the action is a failure.
   def call(state)
-    instance
-      .driver
-      .apply
-      .fmap do |output|
-        state
-          .store(
-            :kitchen_terraform_output,
-            output
-          )
-      end
-      .or do |failure|
-        raise(
-          ::Kitchen::ActionFailed,
-          failure
-        )
-      end
+    state
+      .store(
+        :kitchen_terraform_output,
+        instance
+          .driver
+          .apply
+      )
+  rescue ::Kitchen::Terraform::Error => error
+    raise(
+      ::Kitchen::ActionFailed,
+      error.message
+    )
   end
 end

--- a/lib/kitchen/terraform/client_version_verifier.rb
+++ b/lib/kitchen/terraform/client_version_verifier.rb
@@ -39,10 +39,10 @@ class ::Kitchen::Terraform::ClientVersionVerifier
       .tap do |version|
         requirement
           .satisfied_by? version or
-            fail(
-              ::Kitchen::Terraform::Error,
-              "Terraform v#{version} is not supported; install Terraform ~> v0.11.0"
-            )
+          raise(
+            ::Kitchen::Terraform::Error,
+            "Terraform v#{version} is not supported; install Terraform ~> v0.11.0"
+          )
 
         return "Terraform v#{version} is supported"
       end

--- a/lib/kitchen/terraform/client_version_verifier.rb
+++ b/lib/kitchen/terraform/client_version_verifier.rb
@@ -20,7 +20,7 @@ require "rubygems"
 
 # Verifies that the output of the Terraform version command indicates a supported version of Terraform.
 #
-# Supported:: Terraform version ~> 0.10.2.
+# Supported:: Terraform version >= 0.10.2, < 0.12.0.
 class ::Kitchen::Terraform::ClientVersionVerifier
   # Verifies output from the Terraform version command against the support version.
   #
@@ -52,6 +52,7 @@ class ::Kitchen::Terraform::ClientVersionVerifier
 
   attr_reader :requirement
 
+  # @api private
   def initialize
     @requirement =
       ::Gem::Requirement

--- a/lib/kitchen/terraform/error.rb
+++ b/lib/kitchen/terraform/error.rb
@@ -14,18 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "kitchen/terraform/error"
+require "kitchen/terraform"
 
-module Helpers
-  def fail_after(action:, message:)
-    action
-      .and_raise(
-        ::Kitchen::Terraform::Error,
-        message
-      )
-  end
-
-  def object
-    instance_double ::Object
-  end
+# This class represents errors that occur while Kitchen-Terraform is executing.
+class ::Kitchen::Terraform::Error < ::StandardError
 end

--- a/lib/kitchen/terraform/shell_out.rb
+++ b/lib/kitchen/terraform/shell_out.rb
@@ -14,9 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "dry/monads"
 require "kitchen/terraform"
-require "kitchen/terraform"
+require "kitchen/terraform/error"
 require "mixlib/shellout"
 
 # Terraform commands are run by shelling out and using the
@@ -25,42 +24,36 @@ require "mixlib/shellout"
 # TF_IN_AUTOMATION environment variable as specified by the
 # {https://www.terraform.io/guides/running-terraform-in-automation.html#controlling-terraform-output-in-automation Running Terraform in Automation guide}.
 module ::Kitchen::Terraform::ShellOut
-  extend ::Dry::Monads::Either::Mixin
-  extend ::Dry::Monads::Try::Mixin
-
   # Runs a Terraform command.
   #
   # @param command [::String] the command to run.
   # @param duration [::Integer] the maximum duration in seconds to run the command.
   # @param logger [::Kitchen::Logger] a Test Kitchen logger to capture the output from running the command.
-  # @return [::Dry::Monads::Either] the result of running the command.
+  # @raise [::Kitchen::Terraform::Error] if running the command fails.
+  # @return [::String] the standard output from running the command.
   # @see https://rubygems.org/gems/mixlib-shellout mixlib-shellout
   def self.run(command:, duration: ::Mixlib::ShellOut::DEFAULT_READ_TIMEOUT, logger:)
-    Try ::Mixlib::ShellOut::InvalidCommandOption do
-      ::Mixlib::ShellOut
-        .new(
-          "terraform #{command}",
-          environment: {"TF_IN_AUTOMATION" => "true"},
-          live_stream: logger,
-          timeout: duration
-        )
-    end
-      .bind do |shell_out|
-        Try(
-          ::Errno::EACCES,
-          ::Errno::ENOENT,
-          ::Mixlib::ShellOut::CommandTimeout,
-          ::Mixlib::ShellOut::ShellCommandFailed
-        ) do
-          logger.warn "Running command `#{shell_out.command}`"
-          shell_out.run_command
-          shell_out.error!
-          shell_out.stdout
-        end
+    ::Mixlib::ShellOut
+      .new(
+        "terraform #{command}",
+        environment: {"TF_IN_AUTOMATION" => "true"},
+        live_stream: logger,
+        timeout: duration
+      )
+      .tap do |shell_out|
+        logger.warn "Running command `#{shell_out.command}`"
+        shell_out.run_command
+        shell_out.error!
       end
-      .to_either
-      .or do |error|
-        Left "Running command resulted in failure: #{error}"
-      end
+      .stdout
+  rescue ::Errno::EACCES,
+         ::Errno::ENOENT,
+         ::Mixlib::ShellOut::InvalidCommandOption,
+         ::Mixlib::ShellOut::CommandTimeout,
+         ::Mixlib::ShellOut::ShellCommandFailed => error
+    raise(
+      ::Kitchen::Terraform::Error,
+      "Running command resulted in failure: #{error.message}"
+    )
   end
 end

--- a/lib/kitchen/verifier/terraform/configure_inspec_runner_controls.rb
+++ b/lib/kitchen/verifier/terraform/configure_inspec_runner_controls.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "dry/monads"
 require "kitchen/verifier/terraform"
 
 # Configures a group's InSpec profile controls to be inclued by the Inspec::Runner used by the verifier.
@@ -24,16 +23,19 @@ require "kitchen/verifier/terraform"
 # @see https://github.com/chef/inspec/blob/master/lib/inspec/runner.rb ::Inspec::Runner
 # @see https://www.inspec.io/docs/reference/profiles/ InSpec profiles
 module ::Kitchen::Verifier::Terraform::ConfigureInspecRunnerControls
-  extend ::Dry::Monads::Either::Mixin
-  extend ::Dry::Monads::Maybe::Mixin
-
   # Invokes the function
   #
   # @param group [::Hash] the group being verified.
   # @param options [:Hash] the verifier's Inspec::Runner's options.
   def self.call(group:, options:)
-    Maybe(group[:controls]).bind do |controls|
-      options.store :controls, controls
-    end
+    group[:controls]
+      .tap do |controls|
+        controls and
+          options
+            .store(
+              :controls,
+              controls
+            )
+      end
   end
 end

--- a/lib/kitchen/verifier/terraform/configure_inspec_runner_port.rb
+++ b/lib/kitchen/verifier/terraform/configure_inspec_runner_port.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "dry/monads"
 require "kitchen/verifier/terraform"
 
 # Configures the port for the Inspec::Runner used by the verifier to verify a group.
@@ -23,15 +22,19 @@ require "kitchen/verifier/terraform"
 #
 # @see https://github.com/chef/inspec/blob/master/lib/inspec/runner.rb Inspec::Runner
 module ::Kitchen::Verifier::Terraform::ConfigureInspecRunnerPort
-  extend ::Dry::Monads::Maybe::Mixin
-
   # Invokes the function.
   #
   # @param group [::Hash] the group being verified.
   # @param options [::Hash] the Inspec::Runner's options.
   def self.call(group:, options:)
-    Maybe(group[:port]).bind do |port|
-      options.store "port", port
-    end
+    group[:port]
+      .tap do |port|
+        port and
+          options
+            .store(
+              "port",
+              port
+            )
+      end
   end
 end

--- a/lib/kitchen/verifier/terraform/configure_inspec_runner_ssh_key.rb
+++ b/lib/kitchen/verifier/terraform/configure_inspec_runner_ssh_key.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "dry/monads"
 require "kitchen/verifier/terraform"
 
 # Configures the private SSH key to be used by the verifier's InSpec Runner to verify a group.
@@ -24,20 +23,19 @@ require "kitchen/verifier/terraform"
 # @see https://github.com/chef/inspec/blob/master/lib/inspec/runner.rb InSpec Runner
 # @see https://github.com/test-kitchen/test-kitchen/blob/v1.16.0/lib/kitchen/transport/ssh.rb Test Kitchen SSH Transport
 module ::Kitchen::Verifier::Terraform::ConfigureInspecRunnerSSHKey
-  extend ::Dry::Monads::Maybe::Mixin
-
   # Invoke the function.
   #
   # @param group [::Hash] the group being verified.
   # @param options [::Hash] the Inspec::Runner's options.
   def self.call(group:, options:)
-    Maybe(group[:ssh_key])
-      .bind do |ssh_key|
-        options
-          .store(
-            "key_files",
-            [ssh_key]
-          )
+    group[:ssh_key]
+      .tap do |ssh_key|
+        ssh_key and
+          options
+            .store(
+              "key_files",
+              [ssh_key]
+            )
       end
   end
 end

--- a/lib/kitchen/verifier/terraform/configure_inspec_runner_user.rb
+++ b/lib/kitchen/verifier/terraform/configure_inspec_runner_user.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "dry/monads"
 require "kitchen/verifier/terraform"
 
 # Configures the user for the Inspec::Runner used by the verifier to verify a group.
@@ -23,15 +22,19 @@ require "kitchen/verifier/terraform"
 #
 # @see https://github.com/chef/inspec/blob/master/lib/inspec/runner.rb Inspec::Runner
 module ::Kitchen::Verifier::Terraform::ConfigureInspecRunnerUser
-  extend ::Dry::Monads::Maybe::Mixin
-
   # Invoke the function.
   #
   # @param group [::Hash] the group being verified.
   # @param options [::Hash] the Inspec::Runner's options.
   def self.call(group:, options:)
-    Maybe(group[:username]).bind do |username|
-      options.store "user", username
-    end
+    group[:username]
+      .tap do |username|
+        username and
+          options
+            .store(
+              "user",
+              username
+            )
+      end
   end
 end

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -18,6 +18,7 @@ require "json"
 require "kitchen"
 require "kitchen/driver/terraform"
 require "kitchen/terraform/client_version_verifier"
+require "kitchen/terraform/error"
 require "kitchen/terraform/shell_out"
 require "support/kitchen/terraform/config_attribute/backend_configurations_examples"
 require "support/kitchen/terraform/config_attribute/color_examples"
@@ -83,16 +84,16 @@ require "support/kitchen/terraform/result_in_success_matcher"
     def shell_out_run_failure(command:, message: "mocked `terraform` failure")
       allow(shell_out)
         .to(
-          fail_after(
-            action:
-              receive(:run)
-                .with(
-                  command: command,
-                  duration: 600,
-                  logger: kitchen_logger
-                ),
-            message: message
-          )
+          receive(:run)
+            .with(
+              command: command,
+              duration: 600,
+              logger: kitchen_logger
+            )
+            .and_raise(
+              ::Kitchen::Terraform::Error,
+              message
+            )
         )
     end
 

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -80,6 +80,33 @@ require "support/kitchen/terraform/result_in_success_matcher"
       class_double(::Kitchen::Terraform::ShellOut).as_stubbed_const
     end
 
+    shared_examples "the `terraform workspace` subcommand results in success" do
+      let :workspace do
+        "kitchen-terraform-test-suite-test-platform"
+      end
+
+      let :subcommand do
+        "select"
+      end
+
+      before do
+        allow(shell_out)
+          .to(
+            receive(:run)
+              .with(
+                command: "workspace #{subcommand} #{workspace}",
+                duration: 600,
+                logger: kitchen_logger
+              )
+              .and_return("mocked `terraform workspace #{subcommand} #{workspace}` success")
+          )
+      end
+
+      it do
+        is_expected.to_not raise_error
+      end
+    end
+
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::BackendConfigurations"
 
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::CommandTimeout"
@@ -482,41 +509,15 @@ require "support/kitchen/terraform/result_in_success_matcher"
           end
 
           context "when `terraform workspace select <kitchen-instance>` results in success" do
-            before do
-              allow(shell_out)
-                .to(
-                  receive(:run)
-                    .with(
-                      command: "workspace select kitchen-terraform-test-suite-test-platform",
-                      duration: 600,
-                      logger: kitchen_logger
-                    )
-                    .and_return("mocked `terraform workspace select <kitchen-instance>` success")
-                )
-            end
-
-            it do
-              is_expected.to_not raise_error
-            end
+            it_behaves_like "the `terraform workspace` subcommand results in success"
           end
         end
 
         context "when `terraform workspace new <kitchen-instance>` results in success" do
-          before do
-            allow(shell_out)
-              .to(
-                receive(:run)
-                  .with(
-                    command: "workspace new kitchen-terraform-test-suite-test-platform",
-                    duration: 600,
-                    logger: kitchen_logger
-                  )
-                  .and_return("mocked `terraform workspace new <kitchen-instance>` success")
-              )
-          end
-
-          it do
-            is_expected.to_not raise_error
+          it_behaves_like "the `terraform workspace` subcommand results in success" do
+            let :subcommand do
+              "new"
+            end
           end
         end
       end
@@ -772,21 +773,10 @@ require "support/kitchen/terraform/result_in_success_matcher"
               end
 
               context "when `terraform workspace delete <kitchen-instance>` results in success" do
-                before do
-                  allow(shell_out)
-                    .to(
-                      receive(:run)
-                        .with(
-                          command: "workspace delete kitchen-terraform-test-suite-test-platform",
-                          duration: 600,
-                          logger: kitchen_logger
-                        )
-                        .and_return("mocked `terraform workspace delete <kitchen-instance>` success")
-                    )
-                end
-
-                it do
-                  is_expected.to_not raise_error
+                it_behaves_like "the `terraform workspace` subcommand results in success" do
+                  let :subcommand do
+                    "delete"
+                  end
                 end
               end
             end

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -80,26 +80,26 @@ require "support/kitchen/terraform/result_in_success_matcher"
       class_double(::Kitchen::Terraform::ShellOut).as_stubbed_const
     end
 
-    shared_examples "the `terraform workspace` subcommand results in success" do
-      let :workspace do
-        "kitchen-terraform-test-suite-test-platform"
-      end
+    def shell_out_run_success(command:, return_value: "mocked `terraform` success")
+      allow(shell_out)
+        .to(
+          receive(:run)
+            .with(
+              command: command,
+              duration: kind_of(::Integer),
+              logger: kitchen_logger
+            )
+            .and_return(return_value)
+        )
+    end
 
+    shared_examples "the `terraform workspace <kitchen-instance>` subcommand results in success" do
       let :subcommand do
         "select"
       end
 
       before do
-        allow(shell_out)
-          .to(
-            receive(:run)
-              .with(
-                command: "workspace #{subcommand} #{workspace}",
-                duration: 600,
-                logger: kitchen_logger
-              )
-              .and_return("mocked `terraform workspace #{subcommand} #{workspace}` success")
-          )
+        shell_out_run_success command: "workspace #{subcommand} kitchen-terraform-test-suite-test-platform"
       end
 
       it do
@@ -173,16 +173,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
       context "when `terraform workspace select <kitchen-instance>` results in success" do
         before do
-          allow(shell_out)
-            .to(
-              receive(:run)
-                .with(
-                  command: "workspace select kitchen-terraform-test-suite-test-platform",
-                  duration: 600,
-                  logger: kitchen_logger
-                )
-                .and_return("mocked `terraform workspace select <kitchen-instance>` success")
-            )
+          shell_out_run_success command: "workspace select kitchen-terraform-test-suite-test-platform"
         end
 
         context "when `terraform get` results in failure" do
@@ -209,19 +200,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
         context "when `terraform get` results in success" do
           before do
-            allow(shell_out)
-              .to(
-                receive(:run)
-                  .with(
-                    command:
-                      /get\s
-                        -update\s
-                        #{kitchen_root}/x,
-                    duration: 600,
-                    logger: kitchen_logger
-                  )
-                  .and_return("mocked `terraform get` success")
-              )
+            shell_out_run_success command: "get -update #{kitchen_root}"
           end
 
           context "when `terraform validate` results in failure" do
@@ -248,22 +227,15 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
           context "when `terraform validate` results in success" do
             before do
-              allow(shell_out)
-                .to(
-                  receive(:run)
-                    .with(
-                      command:
-                        /validate\s
-                          -check-variables=true\s
-                          -no-color\s
-                          -var='key=value'\s
-                          -var-file=\/variable\/file\s
-                          #{kitchen_root}/x,
-                      duration: 600,
-                      logger: kitchen_logger
-                    )
-                    .and_return("mocked `terraform validate` success")
-                )
+              shell_out_run_success(
+                command:
+                  /validate\s
+                    -check-variables=true\s
+                    -no-color\s
+                    -var='key=value'\s
+                    -var-file=\/variable\/file\s
+                    #{kitchen_root}/x
+              )
             end
 
             context "when `terraform apply` results in failure" do
@@ -290,27 +262,20 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
             context "when `terraform apply` results in success" do
               before do
-                allow(shell_out)
-                  .to(
-                    receive(:run)
-                      .with(
-                        command:
-                          /apply\s
-                            -lock=true\s
-                            -lock-timeout=0s\s
-                            -input=false\s
-                            -auto-approve=true\s
-                            -no-color\s
-                            -parallelism=10\s
-                            -refresh=true\s
-                            -var='key=value'\s
-                            -var-file=\/variable\/file\s
-                            #{kitchen_root}/x,
-                        duration: 600,
-                        logger: kitchen_logger
-                      )
-                      .and_return("mocked `terraform apply` success")
-                  )
+                shell_out_run_success(
+                  command:
+                    /apply\s
+                      -lock=true\s
+                      -lock-timeout=0s\s
+                      -input=false\s
+                      -auto-approve=true\s
+                      -no-color\s
+                      -parallelism=10\s
+                      -refresh=true\s
+                      -var='key=value'\s
+                      -var-file=\/variable\/file\s
+                      #{kitchen_root}/x
+                )
               end
 
               context "when `terraform output` results in failure" do
@@ -337,16 +302,10 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
               context "when `terraform output` results in success" do
                 before do
-                  allow(shell_out)
-                    .to(
-                      receive(:run)
-                        .with(
-                          command: "output -json",
-                          duration: 600,
-                          logger: kitchen_logger
-                        )
-                        .and_return(terraform_output_value)
-                    )
+                  shell_out_run_success(
+                    command: "output -json",
+                    return_value: terraform_output_value
+                  )
                 end
 
                 context "when the value of the `terraform output` result is not valid JSON" do
@@ -437,29 +396,22 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
       context "when `terraform init` results in success" do
         before do
-          allow(shell_out)
-            .to(
-              receive(:run)
-                .with(
-                  command:
-                    /init\s
-                      -input=false\s
-                      -lock=true\s
-                      -lock-timeout=0s\s
-                      -no-color\s
-                      -upgrade\s
-                      -force-copy\s
-                      -backend=true\s
-                      -backend-config='key=value'\s
-                      -get=true\s
-                      -get-plugins=true\s
-                      -plugin-dir=\/plugin\/directory\s
-                      -verify-plugins=true\s
-                      #{kitchen_root}/x,
-                  duration: 600,
-                  logger: kitchen_logger
-                )
-                .and_return("mocked `terraform init` success")
+          shell_out_run_success(
+            command:
+              /init\s
+                -input=false\s
+                -lock=true\s
+                -lock-timeout=0s\s
+                -no-color\s
+                -upgrade\s
+                -force-copy\s
+                -backend=true\s
+                -backend-config='key=value'\s
+                -get=true\s
+                -get-plugins=true\s
+                -plugin-dir=\/plugin\/directory\s
+                -verify-plugins=true\s
+                #{kitchen_root}/x
             )
         end
 
@@ -509,12 +461,12 @@ require "support/kitchen/terraform/result_in_success_matcher"
           end
 
           context "when `terraform workspace select <kitchen-instance>` results in success" do
-            it_behaves_like "the `terraform workspace` subcommand results in success"
+            it_behaves_like "the `terraform workspace <kitchen-instance>` subcommand results in success"
           end
         end
 
         context "when `terraform workspace new <kitchen-instance>` results in success" do
-          it_behaves_like "the `terraform workspace` subcommand results in success" do
+          it_behaves_like "the `terraform workspace <kitchen-instance>` subcommand results in success" do
             let :subcommand do
               "new"
             end
@@ -564,28 +516,21 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
       context "when `terraform init` results in success" do
         before do
-          allow(shell_out)
-            .to(
-              receive(:run)
-                .with(
-                  command:
-                    /init\s
-                      -input=false\s
-                      -lock=true\s
-                      -lock-timeout=0s\s
-                      -no-color\s
-                      -force-copy\s
-                      -backend=true\s
-                      -backend-config='key=value'\s
-                      -get=true\s
-                      -get-plugins=true\s
-                      -plugin-dir=\/plugin\/directory\s
-                      -verify-plugins=true\s
-                      #{kitchen_root}/x,
-                  duration: 600,
-                  logger: kitchen_logger
-                )
-                .and_return("mocked `terraform init` success")
+          shell_out_run_success(
+            command:
+              /init\s
+                -input=false\s
+                -lock=true\s
+                -lock-timeout=0s\s
+                -no-color\s
+                -force-copy\s
+                -backend=true\s
+                -backend-config='key=value'\s
+                -get=true\s
+                -get-plugins=true\s
+                -plugin-dir=\/plugin\/directory\s
+                -verify-plugins=true\s
+                #{kitchen_root}/x
             )
         end
 
@@ -637,16 +582,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
         context "when `terraform workspace select <kitchen-instance>` results in success" do
           before do
-            allow(shell_out)
-              .to(
-                receive(:run)
-                  .with(
-                    command: "workspace select kitchen-terraform-test-suite-test-platform",
-                    duration: 600,
-                    logger: kitchen_logger
-                  )
-                  .and_return("mocked `terraform workspace select <kitchen-instance>` success")
-              )
+            shell_out_run_success command: "workspace select kitchen-terraform-test-suite-test-platform"
           end
 
           context "when `terraform destroy` results in failure" do
@@ -679,27 +615,20 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
           context "when `terraform destroy` results in success" do
             before do
-              allow(shell_out)
-                .to(
-                  receive(:run)
-                    .with(
-                      command:
-                        /destroy\s
-                          -force\s
-                          -lock=true\s
-                          -lock-timeout=0s\s
-                          -input=false\s
-                          -no-color\s
-                          -parallelism=10\s
-                          -refresh=true\s
-                          -var='key=value'\s
-                          -var-file=\/variable\/file\s
-                          #{kitchen_root}/x,
-                      duration: 600,
-                      logger: kitchen_logger
-                    )
-                    .and_return("mocked `terraform destroy` success")
-                )
+              shell_out_run_success(
+                command:
+                  /destroy\s
+                    -force\s
+                    -lock=true\s
+                    -lock-timeout=0s\s
+                    -input=false\s
+                    -no-color\s
+                    -parallelism=10\s
+                    -refresh=true\s
+                    -var='key=value'\s
+                    -var-file=\/variable\/file\s
+                    #{kitchen_root}/x
+              )
             end
 
             context "when `terraform select default` results in failure" do
@@ -732,16 +661,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
             context "when `terraform workspace select default` results in success" do
               before do
-                allow(shell_out)
-                  .to(
-                    receive(:run)
-                      .with(
-                        command: "workspace select default",
-                        duration: 600,
-                        logger: kitchen_logger
-                      )
-                      .and_return("mocked `terraform workspace select default` success")
-                  )
+                shell_out_run_success command: "workspace select default"
               end
 
               context "when `terraform workspace delete <kitchen-instance>` results in failure" do
@@ -773,7 +693,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
               end
 
               context "when `terraform workspace delete <kitchen-instance>` results in success" do
-                it_behaves_like "the `terraform workspace` subcommand results in success" do
+                it_behaves_like "the `terraform workspace <kitchen-instance>` subcommand results in success" do
                   let :subcommand do
                     "delete"
                   end
@@ -801,6 +721,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
                   receive(:run)
                     .with(
                       command: "version",
+                      duration: 600,
                       logger: kitchen_logger
                     ),
                 message: "mocked `terraform version` failure"
@@ -825,15 +746,10 @@ require "support/kitchen/terraform/result_in_success_matcher"
         end
 
         before do
-          allow(shell_out)
-            .to(
-              receive(:run)
-                .with(
-                  command: "version",
-                  logger: kitchen_logger
-                )
-                .and_return("Terraform v1.2.3")
-            )
+          shell_out_run_success(
+            command: "version",
+            return_value: "Terraform v1.2.3"
+          )
 
           allow(::Kitchen::Terraform::ClientVersionVerifier).to receive(:new).and_return client_version_verifier
         end

--- a/spec/lib/kitchen/provisioner/terraform_spec.rb
+++ b/spec/lib/kitchen/provisioner/terraform_spec.rb
@@ -17,6 +17,7 @@
 require "kitchen"
 require "kitchen/driver/terraform"
 require "kitchen/provisioner/terraform"
+require "kitchen/terraform/error"
 require "support/kitchen/terraform/configurable_examples"
 
 ::RSpec
@@ -70,10 +71,11 @@ require "support/kitchen/terraform/configurable_examples"
           before do
             allow(driver)
               .to(
-                fail_after(
-                  action: receive(:apply),
-                  message: "mocked Driver#create failure"
-                )
+                receive(:apply)
+                  .and_raise(
+                    ::Kitchen::Terraform::Error,
+                    "mocked Driver#create failure"
+                  )
               )
           end
 

--- a/spec/lib/kitchen/terraform/client_version_verifier_spec.rb
+++ b/spec/lib/kitchen/terraform/client_version_verifier_spec.rb
@@ -15,30 +15,28 @@
 # limitations under the License.
 
 require "kitchen/terraform/client_version_verifier"
-require "support/dry/monads/either_matchers"
 
 ::RSpec
   .describe ::Kitchen::Terraform::ClientVersionVerifier do
     describe "#verify" do
       subject do
-        described_class
-          .new
-          .verify(version_output: "Terraform v#{version}")
+        lambda do
+          described_class
+            .new
+            .verify(version_output: "Terraform v#{version}")
+        end
       end
 
       shared_examples "the version is unsupported" do
         it do
           is_expected
-            .to(
-              result_in_failure
-                .with_the_value("Terraform v#{version} is not supported; install Terraform ~> v0.11.0")
-            )
+            .to result_in_failure.with_message "Terraform v#{version} is not supported; install Terraform ~> v0.11.0"
         end
       end
 
       shared_examples "the version is supported" do
         it do
-          is_expected.to result_in_success.with_the_value "Terraform v#{version} is supported"
+          is_expected.to result_in_success.with_message "Terraform v#{version} is supported"
         end
       end
 

--- a/spec/lib/kitchen/terraform/shell_out_spec.rb
+++ b/spec/lib/kitchen/terraform/shell_out_spec.rb
@@ -17,11 +17,21 @@
 require "kitchen"
 require "kitchen/terraform/shell_out"
 require "mixlib/shellout"
-require "support/dry/monads/either_matchers"
 
 ::RSpec
   .describe ::Kitchen::Terraform::ShellOut do
     describe ".run" do
+      subject do
+        proc do
+          described_class
+            .run(
+              command: "command",
+              duration: duration,
+              logger: logger
+            )
+        end
+      end
+
       let :duration do
         1234
       end
@@ -32,15 +42,6 @@ require "support/dry/monads/either_matchers"
 
       let :logger do
         ::Kitchen::Logger.new
-      end
-
-      subject do
-        described_class
-          .run(
-            command: "command",
-            duration: duration,
-            logger: logger
-          )
       end
 
       context "when an invalid command option is sent to the shell out constructor" do
@@ -62,7 +63,7 @@ require "support/dry/monads/either_matchers"
         end
 
         it do
-          is_expected.to result_in_failure.with_the_value matching "invalid command option"
+          is_expected.to result_in_failure.with_message matching "invalid command option"
         end
       end
 
@@ -96,7 +97,7 @@ require "support/dry/monads/either_matchers"
 
         it do
           is_expected
-            .to result_in_failure.with_the_value "Running command resulted in failure: Permission denied - mocked error"
+            .to result_in_failure.with_message "Running command resulted in failure: Permission denied - mocked error"
         end
       end
 
@@ -132,7 +133,7 @@ require "support/dry/monads/either_matchers"
           is_expected
             .to(
               result_in_failure
-                .with_the_value("Running command resulted in failure: No such file or directory - mocked error")
+                .with_message("Running command resulted in failure: No such file or directory - mocked error")
             )
         end
       end
@@ -166,7 +167,7 @@ require "support/dry/monads/either_matchers"
         end
 
         it do
-          is_expected.to result_in_failure.with_the_value "Running command resulted in failure: mocked error"
+          is_expected.to result_in_failure.with_message "Running command resulted in failure: mocked error"
         end
       end
 
@@ -201,7 +202,7 @@ require "support/dry/monads/either_matchers"
           is_expected
             .to(
               result_in_failure
-                .with_the_value(
+                .with_message(
                   matching(
                     "Running command resulted in failure: Expected process to exit with \\[0\\], but received '1'"
                   )
@@ -210,11 +211,11 @@ require "support/dry/monads/either_matchers"
         end
 
         it do
-          is_expected.to result_in_failure.with_the_value matching "stdout"
+          is_expected.to result_in_failure.with_message matching "stdout"
         end
 
         it do
-          is_expected.to result_in_failure.with_the_value matching "stderr"
+          is_expected.to result_in_failure.with_message matching "stderr"
         end
       end
 
@@ -244,7 +245,7 @@ require "support/dry/monads/either_matchers"
         end
 
         it do
-          is_expected.to result_in_success.with_the_value "stdout"
+          is_expected.to result_in_success.with_message "stdout"
         end
       end
     end

--- a/spec/lib/kitchen/verifier/terraform/configure_inspec_runner_attributes_spec.rb
+++ b/spec/lib/kitchen/verifier/terraform/configure_inspec_runner_attributes_spec.rb
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 require "kitchen/verifier/terraform/configure_inspec_runner_attributes"
-require "support/dry/monads/either_matchers"
 
 ::RSpec
   .describe ::Kitchen::Verifier::Terraform::ConfigureInspecRunnerAttributes do
@@ -25,11 +24,13 @@ require "support/dry/monads/either_matchers"
       end
 
       subject do
-        described_class
-          .call(
-            group: group,
-            output: output
-          )
+        lambda do
+          described_class
+            .call(
+              group: group,
+              output: output
+            )
+        end
       end
 
       context "when the value of the Terraform output command result is unexpected" do
@@ -39,7 +40,7 @@ require "support/dry/monads/either_matchers"
 
         it do
           is_expected
-            .to result_in_failure.with_the_value /Configuring InSpec runner attributes resulted in failure: .*\"value\"/
+            .to result_in_failure.with_message /Configuring InSpec runner attributes resulted in failure: .*\"value\"/
         end
       end
 
@@ -56,7 +57,7 @@ require "support/dry/monads/either_matchers"
           is_expected
             .to(
               result_in_failure
-                .with_the_value(/Configuring InSpec runner attributes resulted in failure: .*\"not_output_name\"/)
+                .with_message(/Configuring InSpec runner attributes resulted in failure: .*\"not_output_name\"/)
             )
         end
       end
@@ -74,7 +75,7 @@ require "support/dry/monads/either_matchers"
           is_expected
             .to(
               result_in_success
-                .with_the_value(
+                .with_message(
                   "attribute_name" => "output_name value",
                   "output_name" => "output_name value"
                 )

--- a/spec/lib/kitchen/verifier/terraform/enumerate_groups_and_hostnames_spec.rb
+++ b/spec/lib/kitchen/verifier/terraform/enumerate_groups_and_hostnames_spec.rb
@@ -19,7 +19,7 @@ require "kitchen/verifier/terraform/enumerate_groups_and_hostnames"
 ::RSpec
   .describe ::Kitchen::Verifier::Terraform::EnumerateGroupsAndHostnames do
     describe ".call" do
-      let :passed_block do
+      let :calling_the_method do
         lambda do |block|
           described_class
             .call(
@@ -32,14 +32,18 @@ require "kitchen/verifier/terraform/enumerate_groups_and_hostnames"
 
       context "when a group omits :hostnames" do
         subject do
-          passed_block
+          calling_the_method
         end
 
         let :group do
           {name: "name"}
         end
 
-        it "is called with the group and 'localhost'" do
+        let :output do
+          {}
+        end
+
+        it "yields the group and 'localhost'" do
           is_expected
             .to(
               yield_with_args(
@@ -88,7 +92,7 @@ require "kitchen/verifier/terraform/enumerate_groups_and_hostnames"
 
       context "when the group associates :hostnames with a valid Terraform output name" do
         subject do
-          passed_block
+          calling_the_method
         end
 
         let :output do
@@ -104,7 +108,7 @@ require "kitchen/verifier/terraform/enumerate_groups_and_hostnames"
           {hostnames: "hostnames"}
         end
 
-        it "is called with the group and each resolved hostname" do
+        it "yields the group and each resolved hostname" do
           is_expected
             .to(
               yield_with_args(

--- a/spec/lib/kitchen/verifier/terraform/enumerate_groups_and_hostnames_spec.rb
+++ b/spec/lib/kitchen/verifier/terraform/enumerate_groups_and_hostnames_spec.rb
@@ -57,7 +57,7 @@ require "kitchen/verifier/terraform/enumerate_groups_and_hostnames"
               .call(
                 groups: [group],
                 output: output
-              ) do |group:, hostname:| end
+              )
           end
         end
 

--- a/spec/lib/kitchen/verifier/terraform_spec.rb
+++ b/spec/lib/kitchen/verifier/terraform_spec.rb
@@ -49,6 +49,12 @@ require "support/kitchen/terraform/configurable_examples"
     it_behaves_like "Kitchen::Terraform::Configurable"
 
     describe "#call" do
+      subject do
+        lambda do
+          described_instance.call kitchen_state
+        end
+      end
+
       let :kitchen_instance do
         ::Kitchen::Instance
           .new(
@@ -70,12 +76,6 @@ require "support/kitchen/terraform/configurable_examples"
 
       before do
         described_instance.finalize_config! kitchen_instance
-      end
-
-      subject do
-        lambda do
-          described_instance.call kitchen_state
-        end
       end
 
       context "when the Test Kitchen state omits :kitchen_terraform_output" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@
 
 require "support/coverage"
 require "support/helpers"
+require "support/kitchen/terraform/result_in_failure_matcher"
+require "support/kitchen/terraform/result_in_success_matcher"
 
 ::RSpec.configure do |configuration|
   configuration.color = true

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -18,14 +18,6 @@ require "kitchen/terraform/error"
 
 # This module comprises miscellaneous helper methods to be used by examples.
 module Helpers
-  def fail_after(action:, message:)
-    action
-      .and_raise(
-        ::Kitchen::Terraform::Error,
-        message
-      )
-  end
-
   def object
     instance_double ::Object
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -16,6 +16,7 @@
 
 require "kitchen/terraform/error"
 
+# This module comprises miscellaneous helper methods to be used by examples.
 module Helpers
   def fail_after(action:, message:)
     action

--- a/spec/support/kitchen/terraform/result_in_failure_matcher.rb
+++ b/spec/support/kitchen/terraform/result_in_failure_matcher.rb
@@ -14,44 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "kitchen/terraform/error"
+
 ::RSpec::Matchers
-  .define "result_in_failure" do
-    match do |result|
-      result
-        .failure? and
-        values_match?(
-          value,
-          result.value
+  .define :result_in_failure do
+    supports_block_expectations
+
+    chain(
+      :with_message,
+      :message
+    )
+
+    match notify_expectation_failures: true do |actual|
+      expect(actual)
+        .to(
+          raise_error(
+            ::Kitchen::Terraform::Error,
+            message
+          )
         )
     end
 
-    chain(
-      :with_the_value,
-      :value
-    )
-
-    failure_message do |result|
-      "expected result\n  #{result}\nto be a failure with the value\n  #{value.inspect}"
-    end
-  end
-
-::RSpec::Matchers
-  .define "result_in_success" do
-    match do |result|
-      result
-        .success? and
-        values_match?(
-          value,
-          result.value
-        )
-    end
-
-    chain(
-      :with_the_value,
-      :value
-    )
-
-    failure_message do |result|
-      "expected result\n  #{result}\nto be a success with the value\n  #{value.inspect}"
+    failure_message do |actual|
+      "expected #{actual} to result in a failure with the message #{message.inspect}"
     end
   end

--- a/spec/support/kitchen/terraform/result_in_success_matcher.rb
+++ b/spec/support/kitchen/terraform/result_in_success_matcher.rb
@@ -14,18 +14,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "kitchen/terraform/error"
+::RSpec::Matchers
+  .define :result_in_success do
+    supports_block_expectations
 
-module Helpers
-  def fail_after(action:, message:)
-    action
-      .and_raise(
-        ::Kitchen::Terraform::Error,
-        message
+    chain(
+      :with_message,
+      :message
+    )
+
+    match notify_expectation_failures: true do |actual|
+      actual_message = nil
+      call_actual =
+        proc do
+          actual_message = actual.call
+        end
+
+      expect(call_actual).to_not raise_error
+      values_match?(
+        message,
+        actual_message
       )
-  end
+    end
 
-  def object
-    instance_double ::Object
+    failure_message do |actual|
+      "expected #{actual} to result in a success with the message #{message.inspect}"
+    end
   end
-end


### PR DESCRIPTION
Using regular exception handling reduces complexity and leads to a more accessible design for a larger group of potential contributors. 