### PR TITLE
Add Gitter webhook to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,3 +80,7 @@ jobs:
           repo: newcontext-oss/kitchen-terraform
           tags: true
         skip_cleanup: true
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/3a11f6fb1385c5cdb12b


### PR DESCRIPTION
This change will allow Gitter to display notifications about Travis activity in the chat room.