### PR TITLE
Add in awspec and Docker to allow non rubyists to easily use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+certs/*
+assets/*
+docs/*
+website/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM joshmahowald/cloud-workstation AS baseworkstation
+
+
+
+FROM ruby:alpine
+RUN apk --update add bash  \
+  ca-certificates openssl && update-ca-certificates  
+
+
+ENV PROJ_DIR=/usr/local/src/kitchen-terraform
+WORKDIR $PROJ_DIR
+
+RUN apk add --virtual build-deps gcc libc-dev make
+
+ADD . ${PROJ_DIR}
+COPY docker-entry.sh /usr/local/bin
+RUN bundle install
+
+RUN apk add --no-cache openssh 
+COPY --from=baseworkstation /usr/local/bin/terraform /usr/local/bin/ 
+COPY --from=baseworkstation /usr/local/bin/docker /usr/local/bin/ 
+
+RUN chmod 755 /usr/local/bin/docker-entry.sh
+ENTRYPOINT ["/usr/local/bin/docker-entry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,22 +3,25 @@ FROM joshmahowald/cloud-workstation AS baseworkstation
 
 
 FROM ruby:alpine
-RUN apk --update add bash  \
-  ca-certificates openssl && update-ca-certificates  
+RUN apk --no-cache --update add bash  \
+  ca-certificates openssl openssh && update-ca-certificates  
 
 
 ENV PROJ_DIR=/usr/local/src/kitchen-terraform
 WORKDIR $PROJ_DIR
+ADD Gemfile .
+ADD kitchen-terraform.gemspec .
+ADD lib ./lib
+RUN apk add --virtual .build-deps gcc libc-dev make 
+RUN bundle install && apk del .build-deps
 
-RUN apk add --virtual build-deps gcc libc-dev make
 
-ADD . ${PROJ_DIR}
+
 COPY docker-entry.sh /usr/local/bin
-RUN bundle install
-
-RUN apk add --no-cache openssh 
 COPY --from=baseworkstation /usr/local/bin/terraform /usr/local/bin/ 
 COPY --from=baseworkstation /usr/local/bin/docker /usr/local/bin/ 
-
 RUN chmod 755 /usr/local/bin/docker-entry.sh
-ENTRYPOINT ["/usr/local/bin/docker-entry.sh"]
+
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/docker-entry.sh", "kitchen"]
+CMD = ["info"]

--- a/README.md
+++ b/README.md
@@ -75,3 +75,8 @@ Refer to the
 for example Terraform projects using various
 [Terraform providers](https://www.terraform.io/docs/configuration/providers.html)
 .
+
+
+### With docker
+Please note that when running in docker, some tests that themselves use docker
+Can have issues connecting if you use the `-v /var/run/docker.sock:/var/run/docker.sock` way to have the image start docker images

--- a/README.md
+++ b/README.md
@@ -79,4 +79,27 @@ for example Terraform projects using various
 
 ### With docker
 Please note that when running in docker, some tests that themselves use docker
-Can have issues connecting if you use the `-v /var/run/docker.sock:/var/run/docker.sock` way to have the image start docker images
+Can have issues connecting if you use the `-v /var/run/docker.sock:/var/run/docker.sock` way to have the image start docker images.
+
+You'll need to mount in your credentials with either environment
+variables or your credentials file.  The default working directory is workspace, and you'll want to mount that in.  
+
+The command is passed into  the `kitchen` command, so you can
+give a command of `converge`, `verify`, `test` etc. 
+
+You can build it yourself with a 
+`docker build . -t kitchen-terraform`
+
+
+e.g. 
+`docker run --rm -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+   -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+   -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
+   -v $(pwd):/workspace kitchen-terraform test` or
+
+or if you're using credentials files and have a aws profile
+called personal, you could do:
+`docker run --rm -v $(pwd):/workspace \
+   -v ~/.aws/:/root/.aws:ro  \
+   -e AWS_PROFILE=$AWS_PROFILE \
+  kitchen-terraform test`

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -1,0 +1,6 @@
+#!/bin/ash
+
+# This set's gems in our path, which is useful for things like awsspec
+export GEM_HOME=/usr/local/bundle
+export PATH=$GEM_HOME/bin:$PATH
+$@

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -74,7 +74,9 @@ require "kitchen/terraform/version.rb"
     )
 
   specification.add_runtime_dependency "kitchen-inspec", "~> 0.18"
-
+  
+  specification.add_runtime_dependency "kitchen-verifier-awspec", "~>0.1"
+  
   specification.add_runtime_dependency "mixlib-shellout", "~> 2.2"
 
   specification

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -74,6 +74,7 @@ require "kitchen/terraform/version.rb"
     )
 
   specification.add_runtime_dependency "kitchen-inspec", "~> 0.18"
+  specification.add_runtime_dependency "awspec",  "~> 1.2"
   
   specification.add_runtime_dependency "kitchen-verifier-awspec", "~>0.1"
   


### PR DESCRIPTION
Great job putting this together.

I can see an argument against inclusing awspec, as it targets a particular provider, but packaging both up into a docker image can make it much easier use for those who want to being doing terraform with aws to start doing TDD if they aren't rubyists.   There is an [automated docker build](https://hub.docker.com/r/joshmahowald/kitchen-terraform) I've put up that I'd be happy to change/remove if you want to take this change.  I've also [example repo] (https://github.com/jmahowald/terraform-awspec-example/) to make use of this to see it in action.

