### PR TITLE
Fix branch of icon src in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,37 +287,37 @@ Kitchen-Terraform is maintained by New Context.
 <img
   alt="New Context logo"
   height="25"
-  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/ncs-alane-update-developing/assets/new_context_logo.png"
+  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/master/assets/new_context_logo.png"
   width="25"> [NewContext.com][new-context]
 
 <img
   alt="Twitter logo"
   height="25"
-  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/ncs-alane-update-developing/assets/twitter_logo.png"
+  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/master/assets/twitter_logo.png"
   width="25"> [@NewContext][new-context-twitter]
 
 <img
   alt="LinkedIn logo"
   height="23"
-  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/ncs-alane-update-developing/assets/linkedin_logo.png"
+  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/master/assets/linkedin_logo.png"
   width="25"> [New Context][new-context-linkedin]
 
 <img
   alt="GitHub logo"
   height="25"
-  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/ncs-alane-update-developing/assets/github_logo.png"
+  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/master/assets/github_logo.png"
   width="25"> [@NewContext][new-context-github]
 
 <img
   alt="Email logo"
   height="16"
-  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/ncs-alane-update-developing/assets/email_logo.png"
+  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/master/assets/email_logo.png"
   width="25"> kitchen-terraform@newcontext.com
 
 <img
   alt="Email logo"
   height="16"
-  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/ncs-alane-update-developing/assets/email_logo.png"
+  src="https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/master/assets/email_logo.png"
   width="25"> info@newcontext.com
 
 ## License


### PR DESCRIPTION
Change the `src` to refer to the master branch.