### PR TITLE
Fix backend-config failing on windows machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 * Documented supported Terraform version for ClientVersionVerifier
 
+* Failure on Windows due to use of single quoted arguments for
+  `-backend-config` and `-var`
+
 ## [3.0.0] - 2017-11-28
 
 ### Added

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -10,24 +10,23 @@ require "kitchen/terraform/version.rb"
 
 ::Gem::Specification.new do |specification|
   specification
-    .authors =
-      [
-        "Aaron Lane",
-        "Clay Thomas",
-        "David Begin",
-        "Erik R. Rygg",
-        "Ewa Czechowska",
-        "John Engelman",
-        "Kevin Dickerson",
-        "Kyle Sexton",
-        "Matt Long",
-        "Michael Glenney",
-        "Nell Shamrell-Harrington",
-        "Nick Willever",
-        "Steven A. Burns",
-        "Walter Dolce",
-        "curleighbraces"
-      ]
+    .authors = [
+      "Aaron Lane",
+      "Clay Thomas",
+      "David Begin",
+      "Erik R. Rygg",
+      "Ewa Czechowska",
+      "John Engelman",
+      "Kevin Dickerson",
+      "Kyle Sexton",
+      "Matt Long",
+      "Michael Glenney",
+      "Nell Shamrell-Harrington",
+      "Nick Willever",
+      "Steven A. Burns",
+      "Walter Dolce",
+      "curleighbraces"
+    ]
 
   specification.description = "kitchen-terraform is a set of Test Kitchen plugins for testing Terraform configuration"
 

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -9,22 +9,25 @@
 require "kitchen/terraform/version.rb"
 
 ::Gem::Specification.new do |specification|
-  specification.authors = [
-    "Aaron Lane",
-    "Clay Thomas",
-    "David Begin",
-    "Erik R. Rygg",
-    "Ewa Czechowska",
-    "John Engelman",
-    "Kevin Dickerson",
-    "Kyle Sexton",
-    "Matt Long",
-    "Michael Glenney",
-    "Nell Shamrell-Harrington",
-    "Nick Willever",
-    "Steven A. Burns",
-    "Walter Dolce"
-  ]
+  specification
+    .authors =
+      [
+        "Aaron Lane",
+        "Clay Thomas",
+        "David Begin",
+        "Erik R. Rygg",
+        "Ewa Czechowska",
+        "John Engelman",
+        "Kevin Dickerson",
+        "Kyle Sexton",
+        "Matt Long",
+        "Michael Glenney",
+        "Nell Shamrell-Harrington",
+        "Nick Willever",
+        "Steven A. Burns",
+        "Walter Dolce",
+        "curleighbraces"
+      ]
 
   specification.description = "kitchen-terraform is a set of Test Kitchen plugins for testing Terraform configuration"
 

--- a/lib/kitchen/terraform/config_attribute/backend_configurations.rb
+++ b/lib/kitchen/terraform/config_attribute/backend_configurations.rb
@@ -62,7 +62,7 @@ module ::Kitchen::Terraform::ConfigAttribute::BackendConfigurations
   def config_backend_configurations_flags
     config_backend_configurations
       .map do |key, value|
-        "-backend-config='#{key}=#{value}'"
+        "-backend-config=\"#{key}=#{value}\""
       end
       .join " "
   end

--- a/lib/kitchen/terraform/config_attribute/variables.rb
+++ b/lib/kitchen/terraform/config_attribute/variables.rb
@@ -60,7 +60,7 @@ module ::Kitchen::Terraform::ConfigAttribute::Variables
   def config_variables_flags
     config_variables
       .map do |key, value|
-        "-var='#{key}=#{value}'"
+        "-var=\"#{key}=#{value}\""
       end
       .join " "
   end

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -204,7 +204,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
                   /validate\s
                     -check-variables=true\s
                     -no-color\s
-                    -var='key=value'\s
+                    -var="key=value"\s
                     -var-file=\/variable\/file\s
                     #{kitchen_root}/x
               )
@@ -235,7 +235,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
                       -no-color\s
                       -parallelism=10\s
                       -refresh=true\s
-                      -var='key=value'\s
+                      -var="key=value"\s
                       -var-file=\/variable\/file\s
                       #{kitchen_root}/x
                 )
@@ -555,7 +555,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
                     -no-color\s
                     -parallelism=10\s
                     -refresh=true\s
-                    -var='key=value'\s
+                    -var="key=value"\s
                     -var-file=\/variable\/file\s
                     #{kitchen_root}/x
               )

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -390,7 +390,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
                 -upgrade\s
                 -force-copy\s
                 -backend=true\s
-                -backend-config='key=value'\s
+                -backend-config="key=value"\s
                 -get=true\s
                 -get-plugins=true\s
                 -plugin-dir=\/plugin\/directory\s
@@ -482,7 +482,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
                 -no-color\s
                 -force-copy\s
                 -backend=true\s
-                -backend-config='key=value'\s
+                -backend-config="key=value"\s
                 -get=true\s
                 -get-plugins=true\s
                 -plugin-dir=\/plugin\/directory\s


### PR DESCRIPTION
The single quotes causes the following issue when running on a windows machines ( not tested on linux )

       Error initializing new backend: Error configuring the backend "s3": 7 error(s) occurred:

       * "bucket": required field is not set
       * "region": required field is not set
       * : invalid or unknown key: 'region
       * : invalid or unknown key: 'bucket
       * : invalid or unknown key: 'key
       * : invalid or unknown key: 'role_arn
       * : invalid or unknown key: 'profile

Changing to the above solves the issue and allows the init command to run.

Fixes https://github.com/newcontext-oss/kitchen-terraform/issues/186