### PR TITLE
Use root module directory with TF workspace command

### DIFF
--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -61,7 +61,7 @@ require "kitchen/terraform/shell_out"
 #
 # ===== Creating a Test Terraform Workspace
 #
-#   terraform workspace <new|select> kitchen-terraform-<instance>
+#   terraform workspace <new|select> kitchen-terraform-<instance> <root_module_directory>
 #
 # ==== kitchen destroy
 #
@@ -85,7 +85,7 @@ require "kitchen/terraform/shell_out"
 #
 # ===== Selecting the Test Terraform Workspace
 #
-#   terraform workspace <select|new> kitchen-terraform-<instance>
+#   terraform workspace <select|new> kitchen-terraform-<instance> <root_module_directory>
 #
 # ===== Destroying the Terraform State
 #
@@ -103,11 +103,11 @@ require "kitchen/terraform/shell_out"
 #
 # ===== Selecting the Default Terraform Workspace
 #
-#   terraform workspace select default
+#   terraform workspace select default <root_module_directory>
 #
 # ===== Deleting the Test Terraform Workspace
 #
-#   terraform workspace delete kitchen-terraform-<instance>
+#   terraform workspace delete kitchen-terraform-<instance> <root_module_directory>
 #
 # === Shelling Out
 #
@@ -393,7 +393,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
   def destroy_run_workspace_delete_instance
     ::Kitchen::Terraform::ShellOut
       .run(
-        command: "workspace delete kitchen-terraform-#{instance_name}",
+        command: "workspace delete kitchen-terraform-#{instance_name} #{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )
@@ -403,7 +403,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
   def destroy_run_workspace_select_default
     ::Kitchen::Terraform::ShellOut
       .run(
-        command: "workspace select default",
+        command: "workspace select default #{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )
@@ -418,14 +418,14 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
   def run_workspace_select_instance
     ::Kitchen::Terraform::ShellOut
       .run(
-        command: "workspace select kitchen-terraform-#{instance_name}",
+        command: "workspace select kitchen-terraform-#{instance_name} #{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )
   rescue ::Kitchen::Terraform::Error
     ::Kitchen::Terraform::ShellOut
       .run(
-        command: "workspace new kitchen-terraform-#{instance_name}",
+        command: "workspace new kitchen-terraform-#{instance_name} #{config_root_module_directory}",
         duration: config_command_timeout,
         logger: logger
       )


### PR DESCRIPTION
**Workspace** command accepts optional directory argument which is not passed by kitchen-terraform. This causes error due to mismatching backend config with workspaces.

[Terraform workspace new command's help](https://github.com/hashicorp/terraform/blob/master/command/workspace_new.go#L176)

[BUG in terraform output stops the process](https://github.com/hashicorp/terraform/issues/15761)

_Use-case:_

Assume the following directory structure:
```
├── .kitchen.yml
├── terraform
│   ├── main.tf
│   ├── module
│   │   └── ...
│   ├── outputs.tf
│   ├── terraform.tfstate.d
│   │   └── ...
│   └── variables.tf
└── test
    └── integration
        ├── spec_helper.rb
        ├── ...
        └── variables-kitchen.tfvars
```
```
# > cat kitchen.yml
---
driver:
  name: terraform
  root_module_directory: terraform
...

# > cat terraform/main.tf
provider "aws" {
    region = "${var.aws_region}"
}

terraform {
  backend "s3" {
  }
}
... 

# > bundle exec kitchen verify
-----> Creating <terraform-aws>...
$$$$$$ Running command `terraform init -input=false -lock=true -lock-timeout=0s  -upgrade -force-copy -backend=true  -get=true -get-plugins=true  -verify-plugins=true /data/terraform`
       Upgrading modules...
...
       * provider.aws: version = "~> 1.7"

       Terraform has been successfully initialized!
$$$$$$ Running command `terraform workspace select kitchen-terraform-terraform-aws`
       Backend reinitialization required. Please run "terraform init".
       Reason: Unsetting the previously set backend "s3"
...
       Failed to load backend: Initialization required. Please see the error message above.
```
After this PR:
```
...

       Terraform has been successfully initialized!
$$$$$$ Running command `terraform workspace select kitchen-terraform-terraform-aws /data/terraform`

       Workspace "kitchen-terraform-terraform-aws" doesn't exist.

       You can create this workspace with the "new" subcommand.
$$$$$$ Running command `terraform workspace new kitchen-terraform-terraform-aws /data/terraform`
       Created and switched to workspace "kitchen-terraform-terraform-aws"!

       You're now on a new, empty workspace. Workspaces isolate their state,
       so if you run "terraform plan" Terraform will not see any existing state
       for this configuration.
       Finished creating <terraform-aws> (0m12.44s).
...
```
@ncs-alane Hey, thanks for your awesome work here! Could you please provide me some help on what should be done to make this pass? I think that the unit tests are failing due to the mocked command is different from whats passed. 