### PR TITLE
Fix duplicate RSpec output from Guard

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
+--format doc
 --require spec_helper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,8 +30,6 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
   configuration.fail_fast = true
 
-  configuration.formatter = :documentation
-
   configuration.include ::Helpers
 
   configuration.mock_with :rspec do |mocks|


### PR DESCRIPTION
This branch fixes the issue of Guard producing duplicate RSpec output.