### PR TITLE
3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.3.0] - 2018-03-22
+
 ## [3.2.0] - 2018-03-21
 
 ### Added
@@ -426,7 +428,8 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 * Initial release
 
-[Unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v3.3.0...HEAD
+[3.3.0]: https://github.com/newcontext/kitchen-terraform/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/newcontext/kitchen-terraform/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/newcontext/kitchen-terraform/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/newcontext/kitchen-terraform/compare/v2.1.0...v3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [3.3.0] - 2018-03-22
 
+### Added
+
+* The `lock` configuration attribute of the driver toggles locking of
+  the Terraform state file
+
 ## [3.2.0] - 2018-03-21
 
 ### Added

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -21,6 +21,7 @@ require "kitchen/terraform/command/output"
 require "kitchen/terraform/config_attribute/backend_configurations"
 require "kitchen/terraform/config_attribute/color"
 require "kitchen/terraform/config_attribute/command_timeout"
+require "kitchen/terraform/config_attribute/lock"
 require "kitchen/terraform/config_attribute/lock_timeout"
 require "kitchen/terraform/config_attribute/parallelism"
 require "kitchen/terraform/config_attribute/plugin_directory"
@@ -46,7 +47,7 @@ require "kitchen/terraform/shell_out"
 #
 #   terraform init \
 #     -input=false \
-#     -lock=true \
+#     -lock=<lock> \
 #     -lock-timeout=<lock_timeout>s \
 #     [-no-color] \
 #     -upgrade \
@@ -71,7 +72,7 @@ require "kitchen/terraform/shell_out"
 #
 #   terraform init \
 #     -input=false \
-#     -lock=true \
+#     -lock=<lock> \
 #     -lock-timeout=<lock_timeout>s \
 #     [-no-color] \
 #     -force-copy \
@@ -91,7 +92,7 @@ require "kitchen/terraform/shell_out"
 #
 #   terraform destroy \
 #     -force \
-#     -lock=true \
+#     -lock=<lock> \
 #     -lock-timeout=<lock_timeout>s \
 #     -input=false \
 #     [-no-color] \
@@ -135,9 +136,9 @@ require "kitchen/terraform/shell_out"
 #
 # {include:Kitchen::Terraform::ConfigAttribute::CommandTimeout}
 #
-# ==== root_module_directory
+# ==== lock
 #
-# {include:Kitchen::Terraform::ConfigAttribute::RootModuleDirectory}
+# {include:Kitchen::Terraform::ConfigAttribute::Lock}
 #
 # ==== lock_timeout
 #
@@ -150,6 +151,10 @@ require "kitchen/terraform/shell_out"
 # ==== plugin_directory
 #
 # {include:Kitchen::Terraform::ConfigAttribute::PluginDirectory}
+#
+# ==== root_module_directory
+#
+# {include:Kitchen::Terraform::ConfigAttribute::RootModuleDirectory}
 #
 # ==== variable_files
 #
@@ -178,6 +183,8 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
   include ::Kitchen::Terraform::ConfigAttribute::Color
 
   include ::Kitchen::Terraform::ConfigAttribute::CommandTimeout
+
+  include ::Kitchen::Terraform::ConfigAttribute::Lock
 
   include ::Kitchen::Terraform::ConfigAttribute::LockTimeout
 
@@ -280,7 +287,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
       .run(
         command:
           "apply " \
-            "-lock=true " \
+            "#{config_lock_flag} " \
             "#{config_lock_timeout_flag} " \
             "-input=false " \
             "-auto-approve=true " \
@@ -328,7 +335,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
         command:
           "init " \
             "-input=false " \
-            "-lock=true " \
+            "#{config_lock_flag} " \
             "#{config_lock_timeout_flag} " \
             "#{config_color_flag} " \
             "-upgrade " \
@@ -352,7 +359,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
         command:
           "destroy " \
             "-force " \
-            "-lock=true " \
+            "#{config_lock_flag} " \
             "#{config_lock_timeout_flag} " \
             "-input=false " \
             "#{config_color_flag} " \
@@ -373,7 +380,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
         command:
           "init " \
             "-input=false " \
-            "-lock=true " \
+            "#{config_lock_flag} " \
             "#{config_lock_timeout_flag} " \
             "#{config_color_flag} " \
             "-force-copy " \

--- a/lib/kitchen/provisioner/terraform.rb
+++ b/lib/kitchen/provisioner/terraform.rb
@@ -49,7 +49,7 @@ require "kitchen/terraform/error"
 # ===== Applying the Terraform State Changes
 #
 #   terraform apply\
-#     -lock=true \
+#     -lock=<lock> \
 #     -lock-timeout=<lock_timeout>s \
 #     -input=false \
 #     -auto-approve=true \

--- a/lib/kitchen/terraform/config_attribute/lock.rb
+++ b/lib/kitchen/terraform/config_attribute/lock.rb
@@ -20,7 +20,7 @@ require "kitchen/terraform/config_attribute_cacher"
 require "kitchen/terraform/config_attribute_definer"
 require "kitchen/terraform/config_schemas/boolean"
 
-# This attribute toggles locking of the Terraform state file.
+# This attribute toggles {https://www.terraform.io/docs/state/locking.html locking of the Terraform state file}.
 #
 # Type:: {http://www.yaml.org/spec/1.2/spec.html#id2803629 Boolean}
 # Required:: False

--- a/lib/kitchen/terraform/config_attribute/lock.rb
+++ b/lib/kitchen/terraform/config_attribute/lock.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Copyright 2016 New Context Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen"
+require "kitchen/terraform/config_attribute"
+require "kitchen/terraform/config_attribute_cacher"
+require "kitchen/terraform/config_attribute_definer"
+require "kitchen/terraform/config_schemas/boolean"
+
+# This attribute toggles locking of the Terraform state file.
+#
+# Type:: {http://www.yaml.org/spec/1.2/spec.html#id2803629 Boolean}
+# Required:: False
+# Default:: +true+
+# Example:: <code>lock: false</code>
+#
+# @abstract It must be included by plugin class in order to be used.
+module ::Kitchen::Terraform::ConfigAttribute::Lock
+  # A callback to define the configuration attribute which is invoked when this module is included in a plugin class.
+  #
+  # @param plugin_class [::Kitchen::Configurable] A plugin class.
+  # @return [void]
+  def self.included(plugin_class)
+    ::Kitchen::Terraform::ConfigAttributeDefiner
+      .new(
+        attribute: self,
+        schema: ::Kitchen::Terraform::ConfigSchemas::Boolean
+      )
+      .define plugin_class: plugin_class
+  end
+
+  # @return [::Symbol] the symbol corresponding to the attribute.
+  def self.to_sym
+    :lock
+  end
+
+  extend ::Kitchen::Terraform::ConfigAttributeCacher
+
+  # @return [true]
+  def config_lock_default_value
+    true
+  end
+
+  # @return [::String] the toggle converted to a flag.
+  def config_lock_flag
+    "-lock=#{config_lock}"
+  end
+end

--- a/lib/kitchen/terraform/version.rb
+++ b/lib/kitchen/terraform/version.rb
@@ -17,4 +17,4 @@
 require "kitchen/terraform"
 
 # The version of the kitchen-terraform gem.
-::Kitchen::Terraform::VERSION = "3.2.0".freeze
+::Kitchen::Terraform::VERSION = "3.3.0".freeze

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -23,6 +23,7 @@ require "kitchen/terraform/shell_out"
 require "support/kitchen/terraform/config_attribute/backend_configurations_examples"
 require "support/kitchen/terraform/config_attribute/color_examples"
 require "support/kitchen/terraform/config_attribute/command_timeout_examples"
+require "support/kitchen/terraform/config_attribute/lock_examples"
 require "support/kitchen/terraform/config_attribute/lock_timeout_examples"
 require "support/kitchen/terraform/config_attribute/parallelism_examples"
 require "support/kitchen/terraform/config_attribute/plugin_directory_examples"
@@ -142,6 +143,8 @@ require "support/kitchen/terraform/result_in_success_matcher"
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::CommandTimeout"
 
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::Color"
+
+    it_behaves_like "Kitchen::Terraform::ConfigAttribute::Lock"
 
     it_behaves_like "Kitchen::Terraform::ConfigAttribute::LockTimeout"
 

--- a/spec/support/kitchen/terraform/config_attribute/lock_examples.rb
+++ b/spec/support/kitchen/terraform/config_attribute/lock_examples.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright 2016-2017 New Context Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "support/kitchen/terraform/config_attribute_context"
+
+::RSpec
+  .shared_examples "Kitchen::Terraform::ConfigAttribute::Lock" do
+    include_context(
+      "Kitchen::Terraform::ConfigAttribute",
+      attribute: :lock
+    ) do
+      context "when the config omits :lock" do
+        it_behaves_like(
+          "a default value is used",
+          default_value: true
+        )
+      end
+
+      context "when the config associates :lock with a nonboolean" do
+        it_behaves_like(
+          "the value is invalid",
+          error_message: /lock.*must be boolean/,
+          value: "abc"
+        )
+      end
+
+      context "when the config associates :lock with a boolean" do
+        it_behaves_like(
+          "the value is valid",
+          value: false
+        )
+      end
+    end
+  end


### PR DESCRIPTION
This release adds a `lock` configuration attribute to the driver plugin which toggles locking of the Terraform state file.

fixes #209 