### PR TITLE
Clarify the assumptions of the Read Me example

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,8 @@ which utilizes the [Docker provider][docker-provider].
 
 The test system is assumed to be running Ubuntu 17.04.
 
-Kitchen-Terraform and its dependencies are assumed to have been
-installed on the test system as described in the
-[Installation](#installation) section.
+Terraform, Ruby, and Bundler are assumed to have been installed on the
+test system as described in the [Installation](#installation) section.
 
 The [Docker Community Edition][docker-community-edition] is assumed to
 have been installed on the test system.


### PR DESCRIPTION
Since the example includes the installation of Kitchen-Terraform, this
commit identifies the dependencies which are still assumed to be
installed.