### PR TITLE
Add awspec to extensive tutorial

### DIFF
--- a/docs/tutorials/extensive_kitchen_terraform.html
+++ b/docs/tutorials/extensive_kitchen_terraform.html
@@ -261,13 +261,6 @@ touch <span class="nb">test</span>/integration/extensive_suite/controls/state_fi
 <span class="na">title</span><span class="pi">:</span> <span class="s">Extensive Kitchen-Terraform</span>
 <span class="na">version</span><span class="pi">:</span> <span class="s">0.1.0</span>
 
-<span class="na">depends</span><span class="pi">:</span>
-  <span class="pi">-</span>
-    <span class="c1"># Depending on the inspec-aws project adds additional InSpec resources</span>
-    <span class="c1"># specific to AWS</span>
-    <span class="na">name</span><span class="pi">:</span> <span class="s">aws</span>
-    <span class="na">url</span><span class="pi">:</span> <span class="s">https://github.com/chef/inspec-aws/archive/master.tar.gz</span>
-
 </code></pre></div>          <br><br>
           Populate the InSpec attributes control,
           <p
@@ -363,12 +356,14 @@ touch <span class="nb">test</span>/integration/extensive_suite/controls/state_fi
           , to match the following example.
 <div class="highlight"><pre class="syntax-highlight ruby"><code><span class="c1"># frozen_string_literal: true</span>
 
-<span class="n">reachable_other_host_public_ip_address</span> <span class="o">=</span>
+<span class="nb">require</span> <span class="s2">"awspec"</span>
+
+<span class="n">reachable_other_host_id</span> <span class="o">=</span>
   <span class="c1"># The Terraform configuration under test must define the equivalently named</span>
   <span class="c1"># output</span>
   <span class="n">attribute</span><span class="p">(</span>
-    <span class="s2">"reachable_other_host_public_ip_address"</span><span class="p">,</span>
-    <span class="ss">description: </span><span class="s2">"The public IP address of the AWS EC2 instance which should be reachable"</span>
+    <span class="s2">"reachable_other_host_id"</span><span class="p">,</span>
+    <span class="ss">description: </span><span class="s2">"The ID of the AWS EC2 instance which should be reachable"</span>
   <span class="p">)</span>
 
 <span class="n">control</span> <span class="s2">"reachable_other_host"</span> <span class="k">do</span>
@@ -376,7 +371,11 @@ touch <span class="nb">test</span>/integration/extensive_suite/controls/state_fi
 
   <span class="n">describe</span> <span class="s2">"The other host"</span> <span class="k">do</span>
     <span class="n">subject</span> <span class="k">do</span>
-      <span class="n">host</span> <span class="n">reachable_other_host_public_ip_address</span>
+      <span class="c1"># host is a resource provided by InSpec</span>
+      <span class="n">host</span><span class="p">(</span>
+        <span class="c1"># ec2 is a resource provided by awspec</span>
+        <span class="n">ec2</span><span class="p">(</span><span class="n">reachable_other_host_id</span><span class="p">).</span><span class="nf">public_ip_address</span>
+      <span class="p">)</span>
     <span class="k">end</span>
 
     <span class="n">before</span> <span class="k">do</span>
@@ -520,9 +519,9 @@ The isolated, regional location in which to place the subnet of the module
 <span class="p">}</span>
 
 <span class="c1"># This output is used as an attribute in the reachable_other_host control</span>
-<span class="n">output</span> <span class="s2">"reachable_other_host_public_ip_address"</span> <span class="p">{</span>
-  <span class="n">description</span> <span class="o">=</span> <span class="s2">"The public IP address of the reachable_other_host instance"</span>
-  <span class="n">value</span>       <span class="o">=</span> <span class="s2">"${module.extensive_kitchen_terraform.reachable_other_host_public_ip_address}"</span>
+<span class="n">output</span> <span class="s2">"reachable_other_host_id"</span> <span class="p">{</span>
+  <span class="n">description</span> <span class="o">=</span> <span class="s2">"The ID of the reachable_other_host instance"</span>
+  <span class="n">value</span>       <span class="o">=</span> <span class="s2">"${module.extensive_kitchen_terraform.reachable_other_host_id}"</span>
 <span class="p">}</span>
 
 <span class="c1"># This output is used as an attribute in the inspec_attributes control</span>
@@ -735,9 +734,9 @@ The public key material to use for SSH authentication with the instances
 <span class="c1"># Output Configuration</span>
 
 <span class="c1"># This output is used as an attribute in the reachable_other_host control</span>
-<span class="n">output</span> <span class="s2">"reachable_other_host_public_ip_address"</span> <span class="p">{</span>
-  <span class="n">description</span> <span class="o">=</span> <span class="s2">"The public IP address of the reachable_other_host instance"</span>
-  <span class="n">value</span>       <span class="o">=</span> <span class="s2">"${aws_instance.reachable_other_host.public_ip}"</span>
+<span class="n">output</span> <span class="s2">"reachable_other_host_id"</span> <span class="p">{</span>
+  <span class="n">description</span> <span class="o">=</span> <span class="s2">"The ID of the reachable_other_host instance"</span>
+  <span class="n">value</span>       <span class="o">=</span> <span class="s2">"${aws_instance.reachable_other_host.id}"</span>
 <span class="p">}</span>
 
 <span class="c1"># This output is used to obtain targets for InSpec</span>
@@ -869,11 +868,10 @@ The public key material to use for SSH authentication with the instances
 <div class="highlight"><pre class="syntax-highlight ruby"><code><span class="c1"># frozen_string_literal: true</span>
 
 <span class="n">source</span> <span class="s2">"https://rubygems.org/"</span> <span class="k">do</span>
-  <span class="c1"># aws-sdk is required to leverage the InSpec AWS plugin while it is in initial</span>
-  <span class="c1"># development</span>
+  <span class="c1"># awspec will be required to test AWS resources until Kitchen-Terraform supports the AWS InSpec backend.</span>
   <span class="n">gem</span><span class="p">(</span>
-    <span class="s2">"aws-sdk"</span><span class="p">,</span>
-    <span class="s2">"~&gt; 2.0"</span>
+    <span class="s2">"awspec"</span><span class="p">,</span>
+    <span class="s2">"~&gt; 1.5"</span>
   <span class="p">)</span>
 
   <span class="n">gem</span><span class="p">(</span>

--- a/examples/extensive_kitchen_terraform/Gemfile
+++ b/examples/extensive_kitchen_terraform/Gemfile
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org/" do
-  # aws-sdk is required to leverage the InSpec AWS plugin while it is in initial
-  # development
+  # awspec will be required to test AWS resources until Kitchen-Terraform supports
+  # the AWS InSpec backend
   gem(
-    "aws-sdk",
-    "~> 2.0"
+    "awspec",
+    "~> 1.5"
   )
 
   gem(
     "kitchen-terraform",
-    "~> 3.1"
+    "~> 3.3"
   )
 end

--- a/examples/extensive_kitchen_terraform/module.tf
+++ b/examples/extensive_kitchen_terraform/module.tf
@@ -161,9 +161,9 @@ resource "aws_vpc" "extensive_tutorial" {
 # Output Configuration
 
 # This output is used as an attribute in the reachable_other_host control
-output "reachable_other_host_public_ip_address" {
-  description = "The public IP address of the reachable_other_host instance"
-  value       = "${aws_instance.reachable_other_host.public_ip}"
+output "reachable_other_host_id" {
+  description = "The ID of the reachable_other_host instance"
+  value       = "${aws_instance.reachable_other_host.id}"
 }
 
 # This output is used to obtain targets for InSpec

--- a/examples/extensive_kitchen_terraform/test/fixtures/wrapper/configuration.tf
+++ b/examples/extensive_kitchen_terraform/test/fixtures/wrapper/configuration.tf
@@ -44,9 +44,9 @@ output "instances_ami_operating_system_name" {
 }
 
 # This output is used as an attribute in the reachable_other_host control
-output "reachable_other_host_public_ip_address" {
-  description = "The public IP address of the reachable_other_host instance"
-  value       = "${module.extensive_kitchen_terraform.reachable_other_host_public_ip_address}"
+output "reachable_other_host_id" {
+  description = "The ID of the reachable_other_host instance"
+  value       = "${module.extensive_kitchen_terraform.reachable_other_host_id}"
 }
 
 # This output is used as an attribute in the inspec_attributes control

--- a/examples/extensive_kitchen_terraform/test/integration/extensive_suite/controls/reachable_other_host.rb
+++ b/examples/extensive_kitchen_terraform/test/integration/extensive_suite/controls/reachable_other_host.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-reachable_other_host_public_ip_address =
+require "awspec"
+
+reachable_other_host_id =
   # The Terraform configuration under test must define the equivalently named
   # output
   attribute(
-    "reachable_other_host_public_ip_address",
-    description: "The public IP address of the AWS EC2 instance which should be reachable"
+    "reachable_other_host_id",
+    description: "The ID of the AWS EC2 instance which should be reachable"
   )
 
 control "reachable_other_host" do
@@ -13,7 +15,11 @@ control "reachable_other_host" do
 
   describe "The other host" do
     subject do
-      host reachable_other_host_public_ip_address
+      # host is a resource provided by InSpec
+      host(
+        # ec2 is a resource provided by awspec
+        ec2(reachable_other_host_id).public_ip_address
+      )
     end
 
     before do

--- a/examples/extensive_kitchen_terraform/test/integration/extensive_suite/inspec.yml
+++ b/examples/extensive_kitchen_terraform/test/integration/extensive_suite/inspec.yml
@@ -1,10 +1,3 @@
 name: extensive_suite
 title: Extensive Kitchen-Terraform
 version: 0.1.0
-
-depends:
-  -
-    # Depending on the inspec-aws project adds additional InSpec resources
-    # specific to AWS
-    name: aws
-    url: https://github.com/chef/inspec-aws/archive/master.tar.gz


### PR DESCRIPTION
This commit reintroduces awspec to the extensive tutorial to better
demonstrate AWS testing while support for the AWS InSpec backend is
pending.