### PR TITLE
Replace -force with -auto-approve (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 * Breaking support for concurrency with the following commands:
   `create`, `converge`, `setup`, and `destroy`
 
-* Breaking support for terraform < 0.11.4 with:
+* providing support for terraform >= 0.11.4 with:
   `destroy` <- change -force flag to -auto-approve
+  (this is version wrapped and backwards compatible)
 
 ## [3.3.1] - 2018-04-29
 

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -27,7 +27,8 @@ require "rubygems"
       "Nick Willever",
       "Steven A. Burns",
       "Walter Dolce",
-      "curleighbraces"
+      "curleighbraces",
+      "Gary Foster"
     ]
 
   specification.description = "kitchen-terraform is a set of Test Kitchen plugins for testing Terraform configuration"

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -401,11 +401,16 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
 
   # @api private
   def destroy_run_destroy
+    force_flag = "-force"
+    ::Kitchen::Terraform::Version
+      .if_satisfies requirement: ">=4.0" do
+        force_flag = "-auto-approve"
+      end
     ::Kitchen::Terraform::ShellOut
       .run(
         command:
           "destroy " \
-            "-auto-approve " \
+            "#{force_flag} " \
             "#{lock_flag} " \
             "#{lock_timeout_flag} " \
             "-input=false " \

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -624,11 +624,22 @@ require "support/kitchen/terraform/result_in_success_matcher"
           end
 
           context "when `terraform destroy` results in success" do
+            let :force_flag do
+              "-force"
+            end
+
+            ::Kitchen::Terraform::Version
+              .if_satisfies requirement: ">=4.0" do
+                let :force_flag do
+                  "-auto-approve"
+                end
+              end
+
             before do
               shell_out_run_success(
                 command:
                   /destroy\s
-                    -auto-approve\s
+                    #{force_flag}\s
                     -lock=true\s
                     -lock-timeout=0s\s
                     -input=false\s


### PR DESCRIPTION
Terraform 0.11.4 deprecates the -force flag, so change to -auto-approve
This is a *breaking* change so don't merge until we drop support for
terraform < 0.11.4