### PR TITLE
Update Travis CI URL to the .com domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,4 +516,4 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 [@walterdolce]: https://github.com/walterdolce
 [@xmik]: https://github.com/xmik
 [code climate coverage]: https://codeclimate.com/github/newcontext-oss/kitchen-terraform
-[travis ci build plan]: https://travis-ci.org/newcontext-oss/kitchen-terraform
+[travis ci build plan]: https://travis-ci.com/newcontext-oss/kitchen-terraform

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,4 +209,4 @@ bin/middleman build --build-dir docs
 [terraform-docker-provider]: https://www.terraform.io/docs/providers/docker/index.html
 [terraform]: https://www.terraform.io/
 [test-kitchen]: https://github.com/test-kitchen/test-kitchen/tree/v1.16.0
-[travis-ci]: https://travis-ci.org/newcontext-oss/kitchen-terraform
+[travis-ci]: https://travis-ci.com/newcontext-oss/kitchen-terraform

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Kitchen-Terraform is distributed under the [Apache License][license].
 
 <!-- Markdown links and image definitions -->
 [build-status-shield]: https://img.shields.io/travis/newcontext-oss/kitchen-terraform.svg?style=plastic
-[build-status]: https://travis-ci.org/newcontext-oss/kitchen-terraform
+[build-status]: https://travis-ci.com/newcontext-oss/kitchen-terraform
 [bundler-getting-started]: https://bundler.io/#getting-started
 [bundler-in-depth]: https://bundler.io/gemfile.html
 [bundler]: https://bundler.io/index.html#getting-started

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -70,7 +70,7 @@
           Contribute, report bugs and submit new features at our <a href="https://github.com/newcontext-oss/kitchen-terraform/blob/master/CONTRIBUTING.md" style="color: #32c850;">Github Page</a>
         </p>
         <p class="lead">
-          Check out Kitchen-Terraform on <a href="https://travis-ci.org/newcontext-oss/kitchen-terraform" style="color: #32c850;">Travis CI</a>
+          Check out Kitchen-Terraform on <a href="https://travis-ci.com/newcontext-oss/kitchen-terraform" style="color: #32c850;">Travis CI</a>
         </p>
         <p class="lead">
           Find Kitchen-Terraform on <a href="https://rubygems.org/gems/kitchen-terraform" style="color: #32c850;">rubygems.org</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -92,7 +92,7 @@
             >
           </a>
           <br><br>
-          <a href="https://travis-ci.org/newcontext-oss/kitchen-terraform">
+          <a href="https://travis-ci.com/newcontext-oss/kitchen-terraform">
             <img
               alt="Build status"
               height="18"

--- a/docs/tutorials/extensive_kitchen_terraform.html
+++ b/docs/tutorials/extensive_kitchen_terraform.html
@@ -868,7 +868,8 @@ The public key material to use for SSH authentication with the instances
 <div class="highlight"><pre class="syntax-highlight ruby"><code><span class="c1"># frozen_string_literal: true</span>
 
 <span class="n">source</span> <span class="s2">"https://rubygems.org/"</span> <span class="k">do</span>
-  <span class="c1"># awspec will be required to test AWS resources until Kitchen-Terraform supports the AWS InSpec backend.</span>
+  <span class="c1"># awspec will be required to test AWS resources until Kitchen-Terraform supports</span>
+  <span class="c1"># the AWS InSpec backend</span>
   <span class="n">gem</span><span class="p">(</span>
     <span class="s2">"awspec"</span><span class="p">,</span>
     <span class="s2">"~&gt; 1.5"</span>
@@ -876,7 +877,7 @@ The public key material to use for SSH authentication with the instances
 
   <span class="n">gem</span><span class="p">(</span>
     <span class="s2">"kitchen-terraform"</span><span class="p">,</span>
-    <span class="s2">"~&gt; 3.1"</span>
+    <span class="s2">"~&gt; 3.3"</span>
   <span class="p">)</span>
 <span class="k">end</span>
 

--- a/source/community/index.html.erb
+++ b/source/community/index.html.erb
@@ -13,7 +13,7 @@ title: Community Resources for Kitchen-Terraform
           Contribute, report bugs and submit new features at our <a href="https://github.com/newcontext-oss/kitchen-terraform/blob/master/CONTRIBUTING.md" style="color: #32c850;">Github Page</a>
         </p>
         <p class="lead">
-          Check out Kitchen-Terraform on <a href="https://travis-ci.org/newcontext-oss/kitchen-terraform" style="color: #32c850;">Travis CI</a>
+          Check out Kitchen-Terraform on <a href="https://travis-ci.com/newcontext-oss/kitchen-terraform" style="color: #32c850;">Travis CI</a>
         </p>
         <p class="lead">
           Find Kitchen-Terraform on <a href="https://rubygems.org/gems/kitchen-terraform" style="color: #32c850;">rubygems.org</a>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -35,7 +35,7 @@ title: Kitchen-Terraform
             >
           </a>
           <br><br>
-          <a href="https://travis-ci.org/newcontext-oss/kitchen-terraform">
+          <a href="https://travis-ci.com/newcontext-oss/kitchen-terraform">
             <img
               alt="Build status"
               height="18"


### PR DESCRIPTION
This branch updates all references of travis-ci.org to travis-ci.com in anticipation of Kitchen-Terraform migrating to the new build domain.