### PR TITLE
Refresh badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ jobs:
   include:
   - stage: unit tests and code coverage with newest supported version of ruby
     rvm: 2.5
+    env:
+      - CC_TEST_REPORTER_ID=7574433e1beed630cb9a171c688bb9e010d5028f00f7218d6e845fe138c65168
     before_script:
     - curl --location https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
       > ./cc-test-reporter
@@ -111,6 +113,3 @@ notifications:
   webhooks:
     urls:
     - https://webhooks.gitter.im/e/3a11f6fb1385c5cdb12b
-env:
-  global:
-    secure: k7lAguy8oX6S2DnSumvzzBMT0MYxZDeTWh2bBEXJvpsfIRHjtKHG6XLKLgAHF4oAyrPKBA/KNyy4hHcQwIj5gaez6zSBjXwAZ9ddVsng5BqU3rUj+lPmbGMa1+SpIyGm1KIabA84QEpzeRVXFmUnEMFm8vX6ptuPwBUThapVtZJw8gSgYAV/BxEAVLnMVazacU1/w2tp3+mDOexLcQHxTitqaYJoVXhyubKBMVZfd2UC5xRyT3/Pw+5IvDR+58R9sphfGtg8rBLPgC+BTDdPgZHGPZK4qt4AJLv9aAYJdpWGdrxO6rYeSwpO+ZRxVSQP4T+RINL/pmkcRYaKV+mXsVIpXu6rL0dHlGCPyT22W6OGiK4niKKiPXccjyvwDsA2+0tH1RKbC56kXOzprDREsZzdEdhyE5VWvjv4peIRqMcPSX5KjJlhC6n2zmvtr3tYsuB4KKiUUOQSOSCEaXgbNRew/gOQShwX8a7Q9tb3TytPASNGQaFDBsKE3Z1rynzj7NWXjm+HBWVBmjqsXxzNBjzOlSakAMc/TeK7Iubv7F3P9S1glWvrsz+Rmmwo3WesLZ/ZbhI+4tZxSSiNaJAo5TtWPmA9ZtyWnkKlLbY/ZRYT+X7jFRvtkf9ddDOqoTHrTGAGZHHlOkW3dG6f1mylsGjqfXixzLRWWpAMysEoqv4=

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Build status][build-status-shield]][build-status]
 [![Test coverage][test-coverage-shield]][test-coverage]
 [![Maintainability][maintainability-shield]][maintainability]
-[![Dependencies][gemnasium-shield]][gemnasium]
+[![Dependencies][hakiri-shield]][hakiri]
 
 [![Gitter chat][gitter-shield]][gitter]
 
@@ -379,8 +379,8 @@ Kitchen-Terraform is distributed under the [Apache License][license].
 [gem-downloads-total-shield]: https://img.shields.io/gem/dt/kitchen-terraform.svg?style=plastic
 [gem-downloads-version-shield]: https://img.shields.io/gem/dtv/kitchen-terraform.svg?style=plastic
 [gem-version-shield]: https://img.shields.io/gem/v/kitchen-terraform.svg?style=plastic
-[gemnasium-shield]: https://img.shields.io/gemnasium/newcontext-oss/kitchen-terraform.svg?style=plastic
-[gemnasium]: https://beta.gemnasium.com/projects/github.com/newcontext-oss/kitchen-terraform
+[hakiri-shield]: https://hakiri.io/github/newcontext-oss/kitchen-terraform/master.svg
+[hakiri]: https://hakiri.io/github/newcontext-oss/kitchen-terraform/
 [gitter-shield]: https://img.shields.io/gitter/room/kitchen-terraform/Lobby.svg?style=plastic
 [gitter]: https://gitter.im/kitchen-terraform/Lobby
 [inspec]: https://www.inspec.io/

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Kitchen-Terraform is distributed under the [Apache License][license].
 [kitchen-terraform-logo]: https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/master/assets/logo.png
 [kitchen-terraform-tutorials]: https://newcontext-oss.github.io/kitchen-terraform/tutorials/
 [license]: https://github.com/newcontext-oss/kitchen-terraform/blob/master/LICENSE
-[maintainability-shield]: https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg
+[maintainability-shield]: https://api.codeclimate.com/v1/badges/73d4a2280a30e680bac4/maintainability
 [maintainability]: https://codeclimate.com/github/newcontext-oss/kitchen-terraform/maintainability
 [new-context-github]: https://github.com/newcontext
 [new-context-linkedin]: https://www.linkedin.com/company/-new-context-
@@ -407,7 +407,7 @@ Kitchen-Terraform is distributed under the [Apache License][license].
 [terraform-provisioner]: http://www.rubydoc.info/github/newcontext-oss/kitchen-terraform/Kitchen/Provisioner/Terraform
 [terraform-verifier]: http://www.rubydoc.info/github/newcontext-oss/kitchen-terraform/Kitchen/Verifier/Terraform
 [terraform]: https://www.terraform.io/
-[test-coverage-shield]: https://img.shields.io/codeclimate/c/newcontext-oss/kitchen-terraform.svg
+[test-coverage-shield]: https://api.codeclimate.com/v1/badges/73d4a2280a30e680bac4/test_coverage
 [test-coverage]: https://codeclimate.com/github/newcontext-oss/kitchen-terraform/test_coverage
 [test-kitchen-configuration-file]: https://docs.chef.io/config_yml_kitchen.html
 [test-kitchen]: http://kitchen.ci/index.html

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Kitchen-Terraform is distributed under the [Apache License][license].
 
 <!-- Markdown links and image definitions -->
 
-[build-status-shield]: https://img.shields.io/travis/newcontext-oss/kitchen-terraform.svg?style=plastic
+[build-status-shield]: https://img.shields.io/travis/newcontext-oss/kitchen-terraform.svg
 [build-status]: https://travis-ci.com/newcontext-oss/kitchen-terraform
 [bundler-getting-started]: https://bundler.io/#getting-started
 [bundler-in-depth]: https://bundler.io/gemfile.html
@@ -376,19 +376,19 @@ Kitchen-Terraform is distributed under the [Apache License][license].
 [docker]: https://www.docker.com/
 [docker-community-edition]: https://store.docker.com/editions/community/docker-ce-server-ubuntu
 [docker-provider]: https://www.terraform.io/docs/providers/docker/index.html
-[gem-downloads-total-shield]: https://img.shields.io/gem/dt/kitchen-terraform.svg?style=plastic
-[gem-downloads-version-shield]: https://img.shields.io/gem/dtv/kitchen-terraform.svg?style=plastic
-[gem-version-shield]: https://img.shields.io/gem/v/kitchen-terraform.svg?style=plastic
+[gem-downloads-total-shield]: https://img.shields.io/gem/dt/kitchen-terraform.svg
+[gem-downloads-version-shield]: https://img.shields.io/gem/dtv/kitchen-terraform.svg
+[gem-version-shield]: https://img.shields.io/gem/v/kitchen-terraform.svg
 [hakiri-shield]: https://hakiri.io/github/newcontext-oss/kitchen-terraform/master.svg
 [hakiri]: https://hakiri.io/github/newcontext-oss/kitchen-terraform/
-[gitter-shield]: https://img.shields.io/gitter/room/kitchen-terraform/Lobby.svg?style=plastic
+[gitter-shield]: https://img.shields.io/gitter/room/kitchen-terraform/Lobby.svg
 [gitter]: https://gitter.im/kitchen-terraform/Lobby
 [inspec]: https://www.inspec.io/
 [kitchen-terraform-gem]: https://rubygems.org/gems/kitchen-terraform
 [kitchen-terraform-logo]: https://raw.githubusercontent.com/newcontext-oss/kitchen-terraform/master/assets/logo.png
 [kitchen-terraform-tutorials]: https://newcontext-oss.github.io/kitchen-terraform/tutorials/
 [license]: https://github.com/newcontext-oss/kitchen-terraform/blob/master/LICENSE
-[maintainability-shield]: https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg?style=plastic
+[maintainability-shield]: https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg
 [maintainability]: https://codeclimate.com/github/newcontext-oss/kitchen-terraform/maintainability
 [new-context-github]: https://github.com/newcontext
 [new-context-linkedin]: https://www.linkedin.com/company/-new-context-
@@ -407,7 +407,7 @@ Kitchen-Terraform is distributed under the [Apache License][license].
 [terraform-provisioner]: http://www.rubydoc.info/github/newcontext-oss/kitchen-terraform/Kitchen/Provisioner/Terraform
 [terraform-verifier]: http://www.rubydoc.info/github/newcontext-oss/kitchen-terraform/Kitchen/Verifier/Terraform
 [terraform]: https://www.terraform.io/
-[test-coverage-shield]: https://img.shields.io/codeclimate/c/newcontext-oss/kitchen-terraform.svg?style=plastic
+[test-coverage-shield]: https://img.shields.io/codeclimate/c/newcontext-oss/kitchen-terraform.svg
 [test-coverage]: https://codeclimate.com/github/newcontext-oss/kitchen-terraform/test_coverage
 [test-kitchen-configuration-file]: https://docs.chef.io/config_yml_kitchen.html
 [test-kitchen]: http://kitchen.ci/index.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -113,11 +113,11 @@
               src="https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg?style=plastic"
             >
           </a>
-          <a href="https://beta.gemnasium.com/projects/github.com/newcontext-oss/kitchen-terraform">
+          <a href="https://hakiri.io/github/newcontext-oss/kitchen-terraform/">
             <img
               alt="Dependencies"
               height="18"
-              src="https://img.shields.io/gemnasium/newcontext-oss/kitchen-terraform.svg?style=plastic"
+              src="https://hakiri.io/github/newcontext-oss/kitchen-terraform/master.svg"
             >
           </a>
           <br><br>

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,21 +74,21 @@
             <img
               alt="Gem version"
               height="18"
-              src="https://img.shields.io/gem/v/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/gem/v/kitchen-terraform.svg"
             >
           </a>
           <a href="https://rubygems.org/gems/kitchen-terraform">
             <img
               alt="Gem downloads version"
               height="18"
-              src="https://img.shields.io/gem/dtv/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/gem/dtv/kitchen-terraform.svg"
             >
           </a>
           <a href="https://rubygems.org/gems/kitchen-terraform">
             <img
               alt="Gem downloads total"
               height="18"
-              src="https://img.shields.io/gem/dt/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/gem/dt/kitchen-terraform.svg"
             >
           </a>
           <br><br>
@@ -96,21 +96,21 @@
             <img
               alt="Build status"
               height="18"
-              src="https://img.shields.io/travis/newcontext-oss/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/travis/newcontext-oss/kitchen-terraform.svg"
             >
           </a>
           <a href="https://codeclimate.com/github/newcontext-oss/kitchen-terraform/test_coverage">
             <img
               alt="Test coverage"
               height="18"
-              src="https://img.shields.io/codeclimate/c/newcontext-oss/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/codeclimate/c/newcontext-oss/kitchen-terraform.svg"
             >
           </a>
           <a href="https://codeclimate.com/github/newcontext-oss/kitchen-terraform/maintainability">
             <img
               alt="Maintainability"
               height="18"
-              src="https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg"
             >
           </a>
           <a href="https://hakiri.io/github/newcontext-oss/kitchen-terraform/">
@@ -125,7 +125,7 @@
             <img
               alt="Gitter chat"
               height="18"
-              src="https://img.shields.io/gitter/room/kitchen-terraform/Lobby.svg?style=plastic"
+              src="https://img.shields.io/gitter/room/kitchen-terraform/Lobby.svg"
             >
           </a>
         </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,14 +103,14 @@
             <img
               alt="Test coverage"
               height="18"
-              src="https://img.shields.io/codeclimate/c/newcontext-oss/kitchen-terraform.svg"
+              src="https://api.codeclimate.com/v1/badges/73d4a2280a30e680bac4/test_coverage"
             >
           </a>
           <a href="https://codeclimate.com/github/newcontext-oss/kitchen-terraform/maintainability">
             <img
               alt="Maintainability"
               height="18"
-              src="https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg"
+              src="https://api.codeclimate.com/v1/badges/73d4a2280a30e680bac4/maintainability"
             >
           </a>
           <a href="https://hakiri.io/github/newcontext-oss/kitchen-terraform/">

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -97,12 +97,7 @@ require "rubygems"
       "~> 3.0"
     )
 
-  specification
-    .add_development_dependency(
-      "mini_racer",
-      "~> 0.1.0"
-    )
-
+  specification.add_development_dependency "mini_racer", "~> 0.2.0"
   specification.add_development_dependency "pry", "~> 0.10"
 
   specification.add_development_dependency "pry-coolline", "~> 0.2"

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -17,21 +17,21 @@ title: Kitchen-Terraform
             <img
               alt="Gem version"
               height="18"
-              src="https://img.shields.io/gem/v/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/gem/v/kitchen-terraform.svg"
             >
           </a>
           <a href="https://rubygems.org/gems/kitchen-terraform">
             <img
               alt="Gem downloads version"
               height="18"
-              src="https://img.shields.io/gem/dtv/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/gem/dtv/kitchen-terraform.svg"
             >
           </a>
           <a href="https://rubygems.org/gems/kitchen-terraform">
             <img
               alt="Gem downloads total"
               height="18"
-              src="https://img.shields.io/gem/dt/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/gem/dt/kitchen-terraform.svg"
             >
           </a>
           <br><br>
@@ -39,21 +39,21 @@ title: Kitchen-Terraform
             <img
               alt="Build status"
               height="18"
-              src="https://img.shields.io/travis/newcontext-oss/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/travis/newcontext-oss/kitchen-terraform.svg"
             >
           </a>
           <a href="https://codeclimate.com/github/newcontext-oss/kitchen-terraform/test_coverage">
             <img
               alt="Test coverage"
               height="18"
-              src="https://img.shields.io/codeclimate/c/newcontext-oss/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/codeclimate/c/newcontext-oss/kitchen-terraform.svg"
             >
           </a>
           <a href="https://codeclimate.com/github/newcontext-oss/kitchen-terraform/maintainability">
             <img
               alt="Maintainability"
               height="18"
-              src="https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg?style=plastic"
+              src="https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg"
             >
           </a>
           <a href="https://hakiri.io/github/newcontext-oss/kitchen-terraform/">
@@ -68,7 +68,7 @@ title: Kitchen-Terraform
             <img
               alt="Gitter chat"
               height="18"
-              src="https://img.shields.io/gitter/room/kitchen-terraform/Lobby.svg?style=plastic"
+              src="https://img.shields.io/gitter/room/kitchen-terraform/Lobby.svg"
             >
           </a>
         </p>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -46,14 +46,14 @@ title: Kitchen-Terraform
             <img
               alt="Test coverage"
               height="18"
-              src="https://img.shields.io/codeclimate/c/newcontext-oss/kitchen-terraform.svg"
+              src="https://api.codeclimate.com/v1/badges/73d4a2280a30e680bac4/test_coverage"
             >
           </a>
           <a href="https://codeclimate.com/github/newcontext-oss/kitchen-terraform/maintainability">
             <img
               alt="Maintainability"
               height="18"
-              src="https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg"
+              src="https://api.codeclimate.com/v1/badges/73d4a2280a30e680bac4/maintainability"
             >
           </a>
           <a href="https://hakiri.io/github/newcontext-oss/kitchen-terraform/">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -56,11 +56,11 @@ title: Kitchen-Terraform
               src="https://img.shields.io/codeclimate/maintainability/newcontext-oss/kitchen-terraform.svg?style=plastic"
             >
           </a>
-          <a href="https://beta.gemnasium.com/projects/github.com/newcontext-oss/kitchen-terraform">
+          <a href="https://hakiri.io/github/newcontext-oss/kitchen-terraform/">
             <img
               alt="Dependencies"
               height="18"
-              src="https://img.shields.io/gemnasium/newcontext-oss/kitchen-terraform.svg?style=plastic"
+              src="https://hakiri.io/github/newcontext-oss/kitchen-terraform/master.svg"
             >
           </a>
           <br><br>


### PR DESCRIPTION
This branch replaces the Gemnasium badges with Hakiri badges and updates the Code Climate token which provides data to the test coverage badge.