### PR TITLE
Add verifier.systems[].profile_paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+.cache/
+.DS_Store/
+.sass-cache/
+.solargraph.yml
+.vscode/
+.yardoc/
+*.gem
 **/.bundle/
 **/.idea/
 **/.kitchen.local.yml
@@ -5,12 +12,6 @@
 **/.terraform/
 **/inspec.lock
 **/terraform.tfstate
-*.gem
-.DS_Store/
-.cache/
-.sass-cache/
-.yardoc/
-Gemfile.lock
 bin/
 build/
 certs/gem-private_key.pem
@@ -18,6 +19,7 @@ coverage/
 doc/
 examples/*/Gemfile.lock
 examples/*/test/assets
+Gemfile.lock
 integration/Shell\ Words/Plugin\ Directory/
 terraform_*/
 tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+# Change Log
 
 All notable changes to this project will be documented in this file.
 
@@ -7,6 +7,13 @@ The format is based on
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][unreleased]
+
+### Added
+
+- Systems gained a `profile_paths` attribute which enables the
+  specification of different InSpec profile paths; refer to the
+  [documentation][terraform-verifier-systems-profile-paths] for more
+  details
 
 ## [4.0.0] - 2018-08-13
 
@@ -553,3 +560,4 @@ Gandalf the Free-As-In-Beer
 [travis ci build plan]: https://travis-ci.com/newcontext-oss/kitchen-terraform
 [terraform-issue-17655]: https://github.com/hashicorp/terraform/issues/17655
 [terraform-verifier]: http://www.rubydoc.info/github/newcontext-oss/kitchen-terraform/Kitchen/Verifier/Terraform
+[terraform-verifier-systems-profile-paths]: https://www.rubydoc.info/gems/kitchen-terraform/Kitchen/Verifier/Terraform#label-profile_paths

--- a/lib/kitchen/terraform/config_schemas/system.rb
+++ b/lib/kitchen/terraform/config_schemas/system.rb
@@ -330,6 +330,22 @@ module Kitchen
       #           - cli
       #           - documentation
       #
+      # ====== profile_paths
+      #
+      # The value of the +profile_paths+ key is a sequence of scalars which is used to locate
+      # {https://www.inspec.io/docs/reference/profiles/ InSpec profiles} containing the controls to be executed against
+      # the system.
+      #
+      # <em>Example kitchen.yml</em>
+      #   verifier:
+      #     name: terraform
+      #     systems:
+      #       - name: a system
+      #         backend: local
+      #         profile_paths:
+      #           - /path/to/first/profile
+      #           - /path/to/second/profile
+      #
       # ====== self_signed
       #
       # The value of the +self_signed+ key is a boolean which is used to toggle permission for self-signed certificates
@@ -535,6 +551,7 @@ module Kitchen
         optional(:password).filled :str?
         optional(:path).filled :str?
         optional(:port).value :int?
+        optional(:profile_paths).each :filled?, :str?
         optional(:proxy_command).filled :str?
         optional(:reporter).each(:filled?, :str?)
         optional(:self_signed).value :bool?

--- a/lib/kitchen/terraform/inspec.rb
+++ b/lib/kitchen/terraform/inspec.rb
@@ -65,9 +65,11 @@ module Kitchen
 
       private
 
-      def initialize(options:, profile_path:)
+      def initialize(options:, profile_paths:)
         @runner = ::Inspec::Runner.new options.merge logger: ::Inspec::Log.logger
-        @runner.add_target path: profile_path
+        profile_paths.each do |profile_path|
+          @runner.add_target path: profile_path
+        end
       end
     end
   end

--- a/lib/kitchen/terraform/inspec_with_hosts.rb
+++ b/lib/kitchen/terraform/inspec_with_hosts.rb
@@ -22,27 +22,27 @@ module Kitchen
   module Terraform
     # InSpec instances act as interfaces to the InSpec gem.
     class InSpecWithHosts
-      # exec executes the InSpec controls of an InSpec profile.
+      # exec executes the InSpec controls of InSpec profiles.
       #
       # @raise [::Kitchen::Terraform::Error] if the execution of the InSpec controls fails.
       # @return [void]
       def exec(system:)
         system.each_host do |host:|
           ::Kitchen::Terraform::InSpec
-            .new(options: options.merge(host: host), profile_path: profile_path)
+            .new(options: options.merge(host: host), profile_paths: profile_paths)
             .info(message: "Verifying host #{host} of #{system}").exec
         end
       end
 
       private
 
-      attr_accessor :options, :profile_path
+      attr_accessor :options, :profile_paths
 
       # @param options [::Hash] options for execution.
-      # @param profile_path [::String] the path to the InSpec profile which contains the controls to be executed.
-      def initialize(options:, profile_path:)
+      # @param profile_paths [::Array] the paths to the InSpec profiles which contain the controls to be executed.
+      def initialize(options:, profile_paths:)
         self.options = options
-        self.profile_path = profile_path
+        self.profile_paths = profile_paths
       end
     end
   end

--- a/lib/kitchen/terraform/inspec_without_hosts.rb
+++ b/lib/kitchen/terraform/inspec_without_hosts.rb
@@ -20,24 +20,24 @@ module Kitchen
   module Terraform
     # InSpec instances act as interfaces to the InSpec gem.
     class InSpecWithoutHosts
-      # exec executes the InSpec controls of an InSpec profile.
+      # exec executes the InSpec controls of InSpec profiles.
       #
       # @raise [::Kitchen::Terraform::Error] if the execution of the InSpec controls fails.
       # @return [void]
       def exec(system:)
         ::Kitchen::Terraform::InSpec
-          .new(options: options, profile_path: profile_path).info(message: "Verifying #{system}").exec
+          .new(options: options, profile_paths: profile_paths).info(message: "Verifying #{system}").exec
       end
 
       private
 
-      attr_accessor :options, :profile_path
+      attr_accessor :options, :profile_paths
 
       # @param options [::Hash] options for execution.
-      # @param profile_path [::String] the path to the InSpec profile which contains the controls to be executed.
-      def initialize(options:, profile_path:)
+      # @param profile_paths [::Array] the paths to the InSpec profiles which contain the controls to be executed.
+      def initialize(options:, profile_paths:)
         self.options = options
-        self.profile_path = profile_path
+        self.profile_paths = profile_paths
       end
     end
   end

--- a/lib/kitchen/terraform/system.rb
+++ b/lib/kitchen/terraform/system.rb
@@ -89,15 +89,15 @@ module Kitchen
       # #verify verifies the system by executing InSpec.
       #
       # @param inspec_options [::Hash] the options to be passed to InSpec.
-      # @param inspec_profile_path [::String] the path to the profile which InSpec will execute.
+      # @param inspec_profile_paths [::Array] the paths to the profiles which InSpec will execute.
       # @return [self]
-      def verify(inspec_options:, inspec_profile_path:)
+      def verify(inspec_options:, inspec_profile_paths:)
         if @hosts.empty?
           ::Kitchen::Terraform::InSpecWithoutHosts
         else
           ::Kitchen::Terraform::InSpecWithHosts
         end
-          .new(options: inspec_options.merge(attributes: @attributes), profile_path: inspec_profile_path)
+          .new(options: inspec_options.merge(attributes: @attributes), profile_paths: inspec_profile_paths)
           .exec(system: self)
 
         self

--- a/lib/kitchen/verifier/terraform.rb
+++ b/lib/kitchen/verifier/terraform.rb
@@ -149,8 +149,10 @@ module Kitchen
         ]
       end
 
-      def inspec_profile_path
-        @inspec_profile_path ||= ::File.join config.fetch(:test_base_path), instance.suite.name
+      def inspec_profile_paths(system:)
+        system.fetch :profile_paths do
+          [::File.join(config.fetch(:test_base_path), instance.suite.name)]
+        end
       end
 
       # load_needed_dependencies! loads the InSpec libraries required to verify a Terraform state.
@@ -189,7 +191,7 @@ module Kitchen
           .new(mapping: system)
           .resolve_attrs(system_attrs_resolver: system_attrs_resolver)
           .resolve_hosts(system_hosts_resolver: system_hosts_resolver)
-          .verify(inspec_options: @inspec_options, inspec_profile_path: inspec_profile_path)
+          .verify(inspec_options: @inspec_options, inspec_profile_paths: inspec_profile_paths(system: system))
       end
     end
   end

--- a/spec/lib/kitchen/terraform/config_schemas/system_spec.rb
+++ b/spec/lib/kitchen/terraform/config_schemas/system_spec.rb
@@ -214,6 +214,14 @@ require "kitchen/terraform/config_schemas/system"
       it_behaves_like "an optional integer"
     end
 
+    describe ":profile_paths" do
+      let :attribute do
+        :profile_paths
+      end
+
+      it_behaves_like "an optional array of strings"
+    end
+
     describe ":proxy_command" do
       let :attribute do
         :proxy_command


### PR DESCRIPTION
This branch adds a `profile_paths` attribute to the `systems` attribute.