### PR TITLE
Pin InSpec version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+.cache/
+.DS_Store/
+.sass-cache/
+.solargraph.yml
+.vscode/
+.yardoc/
+*.gem
 **/.bundle/
 **/.idea/
 **/.kitchen.local.yml
@@ -5,12 +12,6 @@
 **/.terraform/
 **/inspec.lock
 **/terraform.tfstate
-*.gem
-.DS_Store/
-.cache/
-.sass-cache/
-.yardoc/
-Gemfile.lock
 bin/
 build/
 certs/gem-private_key.pem
@@ -18,6 +19,7 @@ coverage/
 doc/
 examples/*/Gemfile.lock
 examples/*/test/assets
+Gemfile.lock
 integration/Shell\ Words/Plugin\ Directory/
 terraform_*/
 tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][unreleased]
 
+# [4.0.1] - 2018-09-15
+
+### Fixed
+
+- The version of InSpec was pinned to 2.2.78 as 2.2.101 introduced a
+  breaking change to the InSpec profile attributes system
+
 ## [4.0.0] - 2018-08-13
 
 "An open-source software release is never late. Nor is it early. It
@@ -506,7 +513,8 @@ Gandalf the Free-As-In-Beer
 
 - Initial release
 
-[unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v4.0.0...HEAD
+[unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v4.0.1...HEAD
+[4.0.1]: https://github.com/newcontext/kitchen-terraform/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/newcontext/kitchen-terraform/compare/v3.3.1...v4.0.0
 [3.3.1]: https://github.com/newcontext/kitchen-terraform/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/newcontext/kitchen-terraform/compare/v3.2.0...v3.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][unreleased]
 
-# [4.0.1] - 2018-09-15
+## [4.0.1] - 2018-09-15
 
 ### Fixed
 

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -42,7 +42,7 @@ require "rubygems"
   specification.add_runtime_dependency "dry-types", "~> 0.9"
   specification.add_runtime_dependency "dry-validation", "~> 0.10"
   specification.add_runtime_dependency "mixlib-shellout", "~> 2.2"
-  specification.add_runtime_dependency "inspec", ">= 2.2.34", "< 3"
+  specification.add_runtime_dependency "inspec", "2.2.78"
   specification.add_runtime_dependency "test-kitchen", "~> 1.23"
   specification.cert_chain = ["certs/gem-public_cert.pem"]
   specification.required_ruby_version = [">= 2.3", "< 2.6"]


### PR DESCRIPTION
This branch pins the version of InSpec to ensure that breaking changes are identified before they impact users of Kitchen-Terraform.

Fixes #274 
Fixes #272  