### PR TITLE
v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][unreleased]
 
+## [4.0.2] - 2018-09-26
+
+### Changed
+
+- The version of InSpec was relaxed to include 2.2.70 to enable
+  compatability with ChefDK 3.2.30
+
 ## [4.0.1] - 2018-09-15
 
 ### Fixed
@@ -513,7 +520,8 @@ Gandalf the Free-As-In-Beer
 
 - Initial release
 
-[unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v4.0.1...HEAD
+[unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v4.0.2...HEAD
+[4.0.2]: https://github.com/newcontext/kitchen-terraform/compare/v4.0.1...v4.0.2
 [4.0.1]: https://github.com/newcontext/kitchen-terraform/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/newcontext/kitchen-terraform/compare/v3.3.1...v4.0.0
 [3.3.1]: https://github.com/newcontext/kitchen-terraform/compare/v3.3.0...v3.3.1

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -42,7 +42,7 @@ require "rubygems"
   specification.add_runtime_dependency "dry-types", "~> 0.9"
   specification.add_runtime_dependency "dry-validation", "~> 0.10"
   specification.add_runtime_dependency "mixlib-shellout", "~> 2.2"
-  specification.add_runtime_dependency "inspec", "2.2.78"
+  specification.add_runtime_dependency "inspec", ">= 2.2.70", "<= 2.2.78"
   specification.add_runtime_dependency "test-kitchen", "~> 1.23"
   specification.cert_chain = ["certs/gem-public_cert.pem"]
   specification.required_ruby_version = [">= 2.3", "< 2.6"]

--- a/lib/kitchen/terraform/version.rb
+++ b/lib/kitchen/terraform/version.rb
@@ -72,7 +72,7 @@ module ::Kitchen::Terraform::Version
 
     # @api private
     def value
-      self.value = ::Gem::Version.new "4.0.1" if not @value
+      self.value = ::Gem::Version.new "4.0.2" if not @value
       @value
     end
 

--- a/spec/lib/kitchen/terraform/version_spec.rb
+++ b/spec/lib/kitchen/terraform/version_spec.rb
@@ -24,7 +24,7 @@ require "rubygems"
   end
 
   let :version do
-    ::Gem::Version.new "4.0.1"
+    ::Gem::Version.new "4.0.2"
   end
 
   describe ".assign_plugin_version" do

--- a/spec/support/kitchen/terraform/configurable_examples.rb
+++ b/spec/support/kitchen/terraform/configurable_examples.rb
@@ -35,7 +35,7 @@ require "support/kitchen/instance_context"
     end
 
     it "equals the gem version" do
-      expect(subject.instance_variable_get(:@plugin_version)).to eq "4.0.1"
+      expect(subject.instance_variable_get(:@plugin_version)).to eq "4.0.2"
     end
   end
 


### PR DESCRIPTION
This branch is the release of v4.0.2, which relaxes the pin on inspec to allow 2.2.70.

Fixes #280.