### PR TITLE
Terraform validate configurations driven from .yml

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -35,6 +35,7 @@ suites:
       - default
     driver:
       root_module_directory: test/terraform/attributes
+      validation_configurations: {}
     verifier:
       systems:
         - name: default

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -135,6 +135,10 @@ end
 #
 # {include:Kitchen::Terraform::ConfigAttribute::BackendConfigurations}
 #
+# ==== validation_configurations
+#
+# {include:Kitchen::Terraform::ConfigAttribute::ValidationConfigurations}
+#
 # ==== color
 #
 # {include:Kitchen::Terraform::ConfigAttribute::Color}

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -18,6 +18,7 @@ require "kitchen"
 require "kitchen/terraform/client_version_verifier"
 require "kitchen/terraform/command/output"
 require "kitchen/terraform/config_attribute/backend_configurations"
+require "kitchen/terraform/config_attribute/validation_configurations"
 require "kitchen/terraform/config_attribute/color"
 require "kitchen/terraform/config_attribute/command_timeout"
 require "kitchen/terraform/config_attribute/lock"
@@ -191,6 +192,8 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
 
   include ::Kitchen::Terraform::ConfigAttribute::BackendConfigurations
 
+  include ::Kitchen::Terraform::ConfigAttribute::ValidationConfigurations
+
   include ::Kitchen::Terraform::ConfigAttribute::Color
 
   include ::Kitchen::Terraform::ConfigAttribute::CommandTimeout
@@ -330,7 +333,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
   def apply_run_validate
     ::Kitchen::Terraform::ShellOut.run(
       command: "validate " \
-      "-check-variables=true " \
+      "#{validation_configurations_flags} " \
       "#{color_flag} " \
       "#{variables_flags} " \
       "#{variable_files_flags}",
@@ -346,6 +349,13 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
   def backend_configurations_flags
     config_backend_configurations.map do |key, value|
       "-backend-config=\"#{key}=#{value}\""
+    end.join " "
+  end
+
+  # api private
+  def validation_configurations_flags
+    config_validation_configurations.map do |key, value|
+      "-#{key}=#{value}"
     end.join " "
   end
 

--- a/lib/kitchen/terraform/config_attribute/validation_configurations.rb
+++ b/lib/kitchen/terraform/config_attribute/validation_configurations.rb
@@ -25,7 +25,7 @@ require "kitchen/terraform/config_attribute_type/hash_of_symbols_and_strings"
 # Example::
 #   _
 #     validation_configurations:
-#       check-variables: true
+#       check-variables: "true"
 module ::Kitchen::Terraform::ConfigAttribute::ValidationConfigurations
   ::Kitchen::Terraform::ConfigAttributeType::HashOfSymbolsAndStrings
     .apply(

--- a/lib/kitchen/terraform/config_attribute/validation_configurations.rb
+++ b/lib/kitchen/terraform/config_attribute/validation_configurations.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Copyright 2016 New Context Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen/terraform/config_attribute"
+require "kitchen/terraform/config_attribute_type/hash_of_symbols_and_strings"
+
+# This attribute comprises {https://www.terraform.io/docs/commands/validate.html#check-variables-true check-variables}
+# argument to complete a validate command.
+#
+# Type:: {http://www.yaml.org/spec/1.2/spec.html#id2760142 Mapping of scalars to scalars}
+# Required:: False
+# Example::
+#   _
+#     validation_configurations:
+#       check-variables: true
+module ::Kitchen::Terraform::ConfigAttribute::ValidationConfigurations
+  ::Kitchen::Terraform::ConfigAttributeType::HashOfSymbolsAndStrings
+    .apply(
+      attribute: :validation_configurations,
+      config_attribute: self,
+      default_value:
+        lambda do
+          {"check-variables": "true"}
+        end
+    )
+end

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -21,6 +21,7 @@ require "kitchen/terraform/client_version_verifier"
 require "kitchen/terraform/error"
 require "kitchen/terraform/shell_out"
 require "support/kitchen/terraform/config_attribute/backend_configurations_examples"
+require "support/kitchen/terraform/config_attribute/validation_configurations_examples"
 require "support/kitchen/terraform/config_attribute/color_examples"
 require "support/kitchen/terraform/config_attribute/command_timeout_examples"
 require "support/kitchen/terraform/config_attribute/lock_examples"
@@ -40,6 +41,9 @@ require "support/kitchen/terraform/result_in_success_matcher"
       backend_configurations: {
         string: "\\\"A String\\\"", map: "{ key = \\\"A Value\\\" }",
         list: "[ \\\"Element One\\\", \\\"Element Two\\\" ]",
+      },
+      validation_configurations: {
+        "check-variables": "true"
       },
       color: false,
       kitchen_root: kitchen_root,
@@ -143,6 +147,8 @@ require "support/kitchen/terraform/result_in_success_matcher"
   end
 
   it_behaves_like "Kitchen::Terraform::ConfigAttribute::BackendConfigurations"
+
+  it_behaves_like "Kitchen::Terraform::ConfigAttribute::ValidationConfigurations"
 
   it_behaves_like "Kitchen::Terraform::ConfigAttribute::CommandTimeout"
 

--- a/spec/support/kitchen/terraform/config_attribute/backend_configurations_examples.rb
+++ b/spec/support/kitchen/terraform/config_attribute/backend_configurations_examples.rb
@@ -20,6 +20,7 @@ require "support/kitchen/terraform/config_attribute_type/hash_of_symbols_and_str
   .shared_examples "Kitchen::Terraform::ConfigAttribute::BackendConfigurations" do
     include_context(
       "Kitchen::Terraform::ConfigAttributeType::HashOfSymbolsAndStrings",
-      attribute: :backend_configurations
+      attribute: :backend_configurations,
+      default_value: {}
     )
   end

--- a/spec/support/kitchen/terraform/config_attribute/validation_configurations_examples.rb
+++ b/spec/support/kitchen/terraform/config_attribute/validation_configurations_examples.rb
@@ -17,10 +17,10 @@
 require "support/kitchen/terraform/config_attribute_type/hash_of_symbols_and_strings_examples"
 
 ::RSpec
-  .shared_examples "Kitchen::Terraform::ConfigAttribute::Variables" do
+  .shared_examples "Kitchen::Terraform::ConfigAttribute::ValidationConfigurations" do
     include_context(
       "Kitchen::Terraform::ConfigAttributeType::HashOfSymbolsAndStrings",
-      attribute: :variables,
-      default_value: {}
+      attribute: :validation_configurations,
+      default_value: {"check-variables": "true"}
     )
   end

--- a/spec/support/kitchen/terraform/config_attribute_type/hash_of_symbols_and_strings_examples.rb
+++ b/spec/support/kitchen/terraform/config_attribute_type/hash_of_symbols_and_strings_examples.rb
@@ -17,7 +17,7 @@
 require "support/kitchen/terraform/config_attribute_context"
 
 ::RSpec
-  .shared_examples "Kitchen::Terraform::ConfigAttributeType::HashOfSymbolsAndStrings" do |attribute:|
+  .shared_examples "Kitchen::Terraform::ConfigAttributeType::HashOfSymbolsAndStrings" do |attribute:, default_value:|
     include_context(
       "Kitchen::Terraform::ConfigAttribute",
       attribute: attribute
@@ -25,7 +25,7 @@ require "support/kitchen/terraform/config_attribute_context"
       context "when the config omits #{attribute.inspect}" do
         it_behaves_like(
           "a default value is used",
-          default_value: {}
+          default_value: default_value
         )
       end
 


### PR DESCRIPTION
* Create ValidationConfigurations
* Attach to yml in integration tests and try to blank out
* Fallback to check-variables as default and overridable (terraform 0.12 drops this variable)

This has been checked to be working with v0.12.0-alpha4, the version compatibility is not yet moved ahead but the patch should be directly mergeable without any issues with old terraform versions and any potential changes to the existing kitchen.yml files of users.