### PR TITLE
Remove `TF_WARN_OUTPUT_ERRORS` from `terraform apply`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,6 +22,5 @@ exclude_patterns:
   - "doc/"
   - "docs/"
   - "examples/"
-  - "spec/"
   - "test/integration"
   - "website/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,14 +4,14 @@ plugins:
   bundler-audit:
     enabled: false
   duplication:
-    enabled: true
+    enabled: false
     config:
       languages:
         - "ruby"
   fixme:
     enabled: true
   flog:
-    enabled: true
+    enabled: false
   markdownlint:
     enabled: true
   reek:
@@ -22,5 +22,6 @@ exclude_patterns:
   - "doc/"
   - "docs/"
   - "examples/"
+  - "spec/"
   - "test/integration"
   - "website/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,6 @@ jobs:
     - bundle config --local gemfile ruby-2.5/Gemfile
     - bundle config --local jobs $(nproc --ignore=1)
     - bundle config --local without backend_ssh:development
-    - choco config set cacheLocation "$(pwd)"/chocolatey
     install:
     - bundle install
     - choco install terraform --confirm --no-progress --version=0.11.4
@@ -144,7 +143,6 @@ jobs:
     cache:
       directories:
       - ruby-2.5/vendor/bundle
-      - chocolatey
   - stage: Deploy to RubyGems
     dist: trusty
     language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,7 @@ jobs:
     - bundle config --local gemfile ruby-2.5/Gemfile
     - bundle config --local jobs $(nproc --ignore=1)
     - bundle config --local without backend_ssh:development
+    - choco config set cacheLocation "$(pwd)"/chocolatey
     install:
     - bundle install
     - choco install terraform --confirm --no-progress --version=0.11.4
@@ -143,6 +144,7 @@ jobs:
     cache:
       directories:
       - ruby-2.5/vendor/bundle
+      - chocolatey
   - stage: Deploy to RubyGems
     dist: trusty
     language: ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][unreleased]
 
-## [4.3.0] - 2019-01-19
+## [4.3.0] - 2019-01-20
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][unreleased]
 
+## [4.3.0] - 2019-01-19
+
+### Changed
+
+- `TF_WARN_OUTPUT_ERRORS` is no longer automatically set when running
+  `terraform apply` during `kitchen converge`. This change should allow
+  output errors to be more quickly exposed to the user.
+
 ## [4.2.1] - 2019-01-19
 
 ### Changed
@@ -588,7 +596,8 @@ Gandalf the Free-As-In-Beer
 
 - Initial release
 
-[unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v4.2.1...HEAD
+[unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v4.3.0...HEAD
+[4.3.0]: https://github.com/newcontext/kitchen-terraform/compare/v4.2.1...v4.3.0
 [4.2.1]: https://github.com/newcontext/kitchen-terraform/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/newcontext/kitchen-terraform/compare/v4.1.1...v4.2.0
 [4.1.1]: https://github.com/newcontext/kitchen-terraform/compare/v4.1.0...v4.1.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    kitchen-terraform (4.2.1)
+    kitchen-terraform (4.3.0)
       dry-types (~> 0.9)
       dry-validation (~> 0.10)
       inspec (~> 3.0)

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -397,6 +397,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
       "#{variable_files_flags}",
       options: {
         cwd: config_root_module_directory,
+        environment: {"TF_WARN_OUTPUT_ERRORS" => "true"},
         live_stream: logger,
         timeout: config_command_timeout,
       },

--- a/lib/kitchen/terraform/version.rb
+++ b/lib/kitchen/terraform/version.rb
@@ -72,7 +72,7 @@ module ::Kitchen::Terraform::Version
 
     # @api private
     def value
-      self.value = ::Gem::Version.new "4.2.1" if not @value
+      self.value = ::Gem::Version.new "4.3.0" if not @value
       @value
     end
 

--- a/ruby-2.3/Gemfile.lock
+++ b/ruby-2.3/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    kitchen-terraform (4.2.1)
+    kitchen-terraform (4.3.0)
       dry-types (~> 0.9)
       dry-validation (~> 0.10)
       inspec (~> 3.0)

--- a/ruby-2.4/Gemfile.lock
+++ b/ruby-2.4/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    kitchen-terraform (4.2.1)
+    kitchen-terraform (4.3.0)
       dry-types (~> 0.9)
       dry-validation (~> 0.10)
       inspec (~> 3.0)

--- a/ruby-2.5/Gemfile.lock
+++ b/ruby-2.5/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    kitchen-terraform (4.2.1)
+    kitchen-terraform (4.3.0)
       dry-types (~> 0.9)
       dry-validation (~> 0.10)
       inspec (~> 3.0)

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -524,7 +524,15 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
       context "when `terraform destroy` results in failure" do
         before do
-          shell_out_run_failure command: /destroy/, message: "mocked `terraform destroy` failure"
+          allow(shell_out).to receive(:run).with(
+            command: /destroy/,
+            options: {
+              cwd: kitchen_root,
+              environment: {"TF_WARN_OUTPUT_ERRORS" => "true"},
+              live_stream: kitchen_logger,
+              timeout: command_timeout,
+            },
+          ).and_raise ::Kitchen::Terraform::Error, "mocked `terraform destroy` failure"
         end
 
         specify "should result in an action failed error with the failed command output" do
@@ -536,7 +544,7 @@ require "support/kitchen/terraform/result_in_success_matcher"
 
       context "when `terraform destroy` results in success" do
         before do
-          shell_out_run_success(
+          allow(shell_out).to receive(:run).with(
             command: "destroy " \
             "-auto-approve " \
             "-lock=true " \
@@ -549,7 +557,13 @@ require "support/kitchen/terraform/result_in_success_matcher"
             "-var=\"map={ key = \\\"A Value\\\" }\" " \
             "-var=\"list=[ \\\"Element One\\\", \\\"Element Two\\\" ]\" " \
             "-var-file=\"/Arbitrary Directory/Variable File.tfvars\"",
-          )
+            options: {
+              cwd: kitchen_root,
+              environment: {"TF_WARN_OUTPUT_ERRORS" => "true"},
+              live_stream: kitchen_logger,
+              timeout: command_timeout,
+            },
+          ).and_return "mocked `terraform` success"
         end
 
         context "when `terraform select default` results in failure" do

--- a/spec/lib/kitchen/terraform/shell_out_spec.rb
+++ b/spec/lib/kitchen/terraform/shell_out_spec.rb
@@ -18,217 +18,241 @@ require "kitchen"
 require "kitchen/terraform/shell_out"
 require "mixlib/shellout"
 
-::RSpec
-  .describe ::Kitchen::Terraform::ShellOut do
-    describe ".run" do
-      subject do
-        proc do
-          described_class
-            .run(
-              command: "command",
-              options:
-                {
-                  cwd: "/working/directory",
-                  live_stream: logger,
-                  timeout: duration
-                }
-            )
-        end
-      end
+::RSpec.describe ::Kitchen::Terraform::ShellOut do
+  describe ".run" do
+    let :complete_environment do
+      {"TF_IN_AUTOMATION" => "true", "TF_WARN_OUTPUT_ERRORS" => "1", "FOO" => "bar"}
+    end
 
-      let :duration do
-        1234
-      end
+    let :duration do
+      1234
+    end
 
-      let :environment do
-        {"TF_IN_AUTOMATION" => "true", "TF_WARN_OUTPUT_ERRORS" => "1"}
-      end
+    let :extra_environment do
+      {"FOO" => "bar"}
+    end
 
-      let :logger do
-        ::Kitchen::Logger.new
-      end
+    let :logger do
+      ::Kitchen::Logger.new
+    end
 
-      context "when an invalid command option is sent to the shell out constructor" do
-        before do
-          allow(::Mixlib::ShellOut)
-            .to(
-              receive(:new)
-                .with(
-                  "terraform command",
-                  cwd: "/working/directory",
-                  environment: environment,
-                  live_stream: logger,
-                  timeout: duration
-                )
-                .and_raise(
-                  ::Mixlib::ShellOut::InvalidCommandOption,
-                  "invalid command option"
-                )
-            )
-        end
-
-        it do
-          is_expected.to result_in_failure.with_message matching "invalid command option"
-        end
-      end
-
-      shared_context "when an error occurs" do
-        def mock_run_command(original, *arguments)
-          original
-            .call(*arguments)
-            .tap do |shell_out|
-              allow(shell_out)
-                .to(
-                  receive(:run_command)
-                    .and_raise(
-                      error_class,
-                      "mocked error"
-                    )
-                )
-            end
-        end
-
-        let :new_arguments do
-          [
+    context "when an invalid command option is sent to the shell out constructor" do
+      before do
+        allow(::Mixlib::ShellOut).to(
+          receive(:new).with(
             "terraform command",
-            {
+            cwd: "/working/directory",
+            environment: complete_environment,
+            live_stream: logger,
+            timeout: duration,
+          ).and_raise(::Mixlib::ShellOut::InvalidCommandOption, "invalid command option")
+        )
+      end
+
+      specify "should raise an error with the invalid command option error message" do
+        expect do
+          described_class.run(
+            command: "command",
+            options: {
               cwd: "/working/directory",
-              environment: environment,
+              environment: extra_environment,
               live_stream: logger,
-              timeout: duration
-            }
-          ]
-        end
+              timeout: duration,
+            },
+          )
+        end.to result_in_failure.with_message matching "invalid command option"
+      end
+    end
 
-        before do
-          allow(::Mixlib::ShellOut)
-            .to(
-              receive(:new)
-                .with(*new_arguments)
-                .and_wrap_original(&method(:mock_run_command))
-            )
+    shared_context "when an error occurs" do
+      def mock_run_command(original, *arguments)
+        original.call(*arguments).tap do |shell_out|
+          allow(shell_out).to receive(:run_command).and_raise error_class, "mocked error"
         end
       end
 
-      context "when a permissions error occurs" do
-        include_context "when an error occurs"
-
-        let :error_class do
-          ::Errno::EACCES
-        end
-
-        it do
-          is_expected
-            .to result_in_failure.with_message "Running command resulted in failure: Permission denied - mocked error"
-        end
+      let :new_arguments do
+        [
+          "terraform command",
+          {
+            cwd: "/working/directory",
+            environment: complete_environment,
+            live_stream: logger,
+            timeout: duration,
+          },
+        ]
       end
 
-      context "when an entry error occurs" do
-        include_context "when an error occurs"
+      before do
+        allow(::Mixlib::ShellOut).to receive(:new).with(*new_arguments).and_wrap_original(&method(:mock_run_command))
+      end
+    end
 
-        let :error_class do
-          ::Errno::ENOENT
-        end
+    context "when a permissions error occurs" do
+      include_context "when an error occurs"
 
-        it do
-          is_expected
-            .to(
-              result_in_failure
-                .with_message("Running command resulted in failure: No such file or directory - mocked error")
-            )
-        end
+      let :error_class do
+        ::Errno::EACCES
       end
 
-      context "when a timeout error occurs" do
-        include_context "when an error occurs"
+      specify "should raise an error with the permissions error message" do
+        expect do
+          described_class.run(
+            command: "command",
+            options: {
+              cwd: "/working/directory",
+              environment: extra_environment,
+              live_stream: logger,
+              timeout: duration,
+            },
+          )
+        end.to result_in_failure.with_message "Running command resulted in failure: Permission denied - mocked error"
+      end
+    end
 
-        let :error_class do
-          ::Mixlib::ShellOut::CommandTimeout
-        end
+    context "when an entry error occurs" do
+      include_context "when an error occurs"
 
-        it do
-          is_expected.to result_in_failure.with_message "Running command resulted in failure: mocked error"
-        end
+      let :error_class do
+        ::Errno::ENOENT
       end
 
-      context "when the command exits with a nonzero value" do
-        before do
-          allow(::Mixlib::ShellOut)
-            .to(
-              receive(:new)
-                .with(
-                  "terraform command",
-                  cwd: "/working/directory",
-                  environment: environment,
-                  live_stream: logger,
-                  timeout: duration
-                )
-                .and_wrap_original do |original, *arguments|
-                  original
-                    .call(*arguments)
-                    .tap do |shell_out|
-                      allow(shell_out).to receive(:exitstatus).and_return 1
+      specify "should raise an error with the entry error message" do
+        expect do
+          described_class.run(
+            command: "command",
+            options: {
+              cwd: "/working/directory",
+              environment: extra_environment,
+              live_stream: logger,
+              timeout: duration,
+            },
+          )
+        end.to result_in_failure.with_message(
+          "Running command resulted in failure: No such file or directory - mocked error"
+        )
+      end
+    end
 
-                      allow(shell_out).to receive(:run_command).and_return shell_out
+    context "when a timeout error occurs" do
+      include_context "when an error occurs"
 
-                      allow(shell_out).to receive(:stderr).and_return "stderr"
-
-                      allow(shell_out).to receive(:stdout).and_return "stdout"
-                    end
-                end
-            )
-        end
-
-        it do
-          is_expected
-            .to(
-              result_in_failure
-                .with_message(
-                  matching(
-                    "Running command resulted in failure: Expected process to exit with \\[0\\], but received '1'"
-                  )
-                )
-            )
-        end
-
-        it do
-          is_expected.to result_in_failure.with_message matching "stdout"
-        end
-
-        it do
-          is_expected.to result_in_failure.with_message matching "stderr"
-        end
+      let :error_class do
+        ::Mixlib::ShellOut::CommandTimeout
       end
 
-      context "when the command exits with a zero value" do
-        before do
-          allow(::Mixlib::ShellOut)
-            .to(
-              receive(:new)
-                .with(
-                  "terraform command",
-                  cwd: "/working/directory",
-                  environment: environment,
-                  live_stream: logger,
-                  timeout: duration
-                )
-                .and_wrap_original do |original, *arguments|
-                  original
-                    .call(*arguments)
-                    .tap do |shell_out|
-                      allow(shell_out).to receive(:exitstatus).and_return 0
+      specify "should raise an error with the timeout error message" do
+        expect do
+          described_class.run(
+            command: "command",
+            options: {
+              cwd: "/working/directory",
+              environment: extra_environment,
+              live_stream: logger,
+              timeout: duration,
+            },
+          )
+        end.to result_in_failure.with_message "Running command resulted in failure: mocked error"
+      end
+    end
 
-                      allow(shell_out).to receive(:run_command).and_return shell_out
+    context "when the command exits with a nonzero value" do
+      before do
+        allow(::Mixlib::ShellOut).to(
+          receive(:new).with(
+            "terraform command",
+            cwd: "/working/directory",
+            environment: complete_environment,
+            live_stream: logger,
+            timeout: duration,
+          ).and_wrap_original do |original, *arguments|
+            original.call(*arguments).tap do |shell_out|
+              allow(shell_out).to receive(:exitstatus).and_return 1
+              allow(shell_out).to receive(:run_command).and_return shell_out
+              allow(shell_out).to receive(:stderr).and_return "stderr"
+              allow(shell_out).to receive(:stdout).and_return "stdout"
+            end
+          end
+        )
+      end
 
-                      allow(shell_out).to receive(:stdout).and_return "stdout"
-                    end
-                end
-            )
-        end
+      specify "should raise an error with the nonzero value message" do
+        expect do
+          described_class.run(
+            command: "command",
+            options: {
+              cwd: "/working/directory",
+              environment: extra_environment,
+              live_stream: logger,
+              timeout: duration,
+            },
+          )
+        end.to result_in_failure.with_message(
+          matching("Running command resulted in failure: Expected process to exit with \\[0\\], but received '1'")
+        )
+      end
 
-        it do
-          is_expected.to result_in_success.with_message "stdout"
-        end
+      specify "should raise an error with the stdout" do
+        expect do
+          described_class.run(
+            command: "command",
+            options: {
+              cwd: "/working/directory",
+              environment: extra_environment,
+              live_stream: logger,
+              timeout: duration,
+            },
+          )
+        end.to result_in_failure.with_message matching "stdout"
+      end
+
+      specify "should raise an error with the stderr" do
+        expect do
+          described_class.run(
+            command: "command",
+            options: {
+              cwd: "/working/directory",
+              environment: extra_environment,
+              live_stream: logger,
+              timeout: duration,
+            },
+          )
+        end.to result_in_failure.with_message matching "stderr"
+      end
+    end
+
+    context "when the command exits with a zero value" do
+      before do
+        allow(::Mixlib::ShellOut).to(
+          receive(:new).with(
+            "terraform command",
+            cwd: "/working/directory",
+            environment: complete_environment,
+            live_stream: logger,
+            timeout: duration,
+          ).and_wrap_original do |original, *arguments|
+            original.call(*arguments).tap do |shell_out|
+              allow(shell_out).to receive(:exitstatus).and_return 0
+              allow(shell_out).to receive(:run_command).and_return shell_out
+              allow(shell_out).to receive(:stdout).and_return "stdout"
+            end
+          end
+        )
+      end
+
+      specify "should yield the stdout" do
+        expect do
+          described_class.run(
+            command: "command",
+            options: {
+              cwd: "/working/directory",
+              environment: extra_environment,
+              live_stream: logger,
+              timeout: duration,
+            },
+          )
+        end.to result_in_success.with_message "stdout"
       end
     end
   end
+end

--- a/spec/lib/kitchen/terraform/version_spec.rb
+++ b/spec/lib/kitchen/terraform/version_spec.rb
@@ -24,7 +24,7 @@ require "rubygems"
   end
 
   let :version do
-    ::Gem::Version.new "4.2.1"
+    ::Gem::Version.new "4.3.0"
   end
 
   describe ".assign_plugin_version" do

--- a/spec/support/kitchen/terraform/configurable_examples.rb
+++ b/spec/support/kitchen/terraform/configurable_examples.rb
@@ -35,7 +35,7 @@ require "support/kitchen/instance_context"
     end
 
     it "equals the gem version" do
-      expect(subject.instance_variable_get(:@plugin_version)).to eq "4.2.1"
+      expect(subject.instance_variable_get(:@plugin_version)).to eq "4.3.0"
     end
   end
 


### PR DESCRIPTION
This branch fixes #314.

The Code Climate configuration is simplified to remove plugins which are redundant due to core Code Climate behaviour.

Chocolatey downloads are cached to speed up the Windows build on Travis CI.