### PR TITLE
v4.5.0: debug logging of `terraform output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][unreleased]
 
+## [4.5.0] - 2019-04-10
+
+### Changed
+
+- The output of `terraform output` is logged at the debug level to
+  prevent sensitive output values from being printed by default. This
+  output can be viewed by enabling the debug log level. For example:
+  `kitchen converge INSTANCE --log-level=debug`
+
 ## [4.4.0] - 2019-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -618,7 +618,8 @@ Gandalf the Free-As-In-Beer
 
 - Initial release
 
-[unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v4.4.0...HEAD
+[unreleased]: https://github.com/newcontext/kitchen-terraform/compare/v4.5.0...HEAD
+[4.5.0]: https://github.com/newcontext/kitchen-terraform/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/newcontext/kitchen-terraform/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/newcontext/kitchen-terraform/compare/v4.2.1...v4.3.0
 [4.2.1]: https://github.com/newcontext/kitchen-terraform/compare/v4.2.0...v4.2.1

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -30,6 +30,7 @@ require "kitchen/terraform/config_attribute/variable_files"
 require "kitchen/terraform/config_attribute/variables"
 require "kitchen/terraform/config_attribute/verify_version"
 require "kitchen/terraform/configurable"
+require "kitchen/terraform/debug_logger"
 require "kitchen/terraform/shell_out"
 require "kitchen/terraform/verify_version"
 require "shellwords"
@@ -275,15 +276,16 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
     run_workspace_select_instance
     ::Kitchen::Terraform::Command::Output.run(
       client: config_client,
-      options: {
-        cwd: config_root_module_directory, live_stream: logger, timeout: config_command_timeout,
-      }, &block
+      options: {cwd: config_root_module_directory,  live_stream: @debug_logger,  timeout: config_command_timeout},
+      &block
     )
   rescue ::Kitchen::Terraform::Error => error
     raise ::Kitchen::ActionFailed, error.message
   end
 
   private
+
+  attr_accessor :debug_logger
 
   def apply_run
     apply_run_get
@@ -450,6 +452,11 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
         timeout: config_command_timeout,
       },
     )
+  end
+
+  def initialize(config = {})
+    super
+    self.debug_logger = ::Kitchen::Terraform::DebugLogger.new logger
   end
 
   # @api private

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -276,7 +276,7 @@ class ::Kitchen::Driver::Terraform < ::Kitchen::Driver::Base
     run_workspace_select_instance
     ::Kitchen::Terraform::Command::Output.run(
       client: config_client,
-      options: {cwd: config_root_module_directory,  live_stream: @debug_logger,  timeout: config_command_timeout},
+      options: {cwd: config_root_module_directory,  live_stream: debug_logger,  timeout: config_command_timeout},
       &block
     )
   rescue ::Kitchen::Terraform::Error => error

--- a/lib/kitchen/terraform/debug_logger.rb
+++ b/lib/kitchen/terraform/debug_logger.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright 2016 New Context Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "delegate"
+
+module Kitchen
+  module Terraform
+    # This class delegates to a logger but ensures the debug level is the default level used for logging messages.
+    class DebugLogger < ::SimpleDelegator
+      # This method overrides the #<< method of the delegate to call #debug.
+      #
+      # @param message [#to_s] the message to be logged.
+      # @return [nil, true] if the given severity is high enough for this particular logger then return
+      #   <code>nil</code>; else return <code>true</code>.
+      def <<(message)
+        debug message
+      end
+    end
+  end
+end

--- a/lib/kitchen/terraform/version.rb
+++ b/lib/kitchen/terraform/version.rb
@@ -72,7 +72,7 @@ module ::Kitchen::Terraform::Version
 
     # @api private
     def value
-      self.value = ::Gem::Version.new "4.4.0" if not @value
+      self.value = ::Gem::Version.new "4.5.0" if not @value
       @value
     end
 

--- a/ruby-2.3/Gemfile.lock
+++ b/ruby-2.3/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (9.5.0)
+    autoprefixer-rails (9.5.1)
       execjs
     aws-eventstream (1.0.2)
     aws-sdk (2.11.256)
@@ -349,7 +349,7 @@ GEM
     rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-its (1.2.0)
+    rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
     rspec-mocks (3.8.0)

--- a/ruby-2.3/Gemfile.lock
+++ b/ruby-2.3/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    kitchen-terraform (4.4.0)
+    kitchen-terraform (4.5.0)
       dry-types (~> 0.14.0)
       dry-validation (= 0.13.0)
       inspec (~> 3.0)

--- a/ruby-2.4/Gemfile.lock
+++ b/ruby-2.4/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (9.5.0)
+    autoprefixer-rails (9.5.1)
       execjs
     aws-eventstream (1.0.2)
     aws-sdk (2.11.256)
@@ -349,7 +349,7 @@ GEM
     rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-its (1.2.0)
+    rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
     rspec-mocks (3.8.0)

--- a/ruby-2.4/Gemfile.lock
+++ b/ruby-2.4/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    kitchen-terraform (4.4.0)
+    kitchen-terraform (4.5.0)
       dry-types (~> 0.14.0)
       dry-validation (= 0.13.0)
       inspec (~> 3.0)

--- a/ruby-2.5/Gemfile.lock
+++ b/ruby-2.5/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (9.5.0)
+    autoprefixer-rails (9.5.1)
       execjs
     aws-eventstream (1.0.2)
     aws-sdk (2.11.256)
@@ -349,7 +349,7 @@ GEM
     rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-its (1.2.0)
+    rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
     rspec-mocks (3.8.0)

--- a/ruby-2.5/Gemfile.lock
+++ b/ruby-2.5/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    kitchen-terraform (4.4.0)
+    kitchen-terraform (4.5.0)
       dry-types (~> 0.14.0)
       dry-validation (= 0.13.0)
       inspec (~> 3.0)

--- a/ruby-2.6/Gemfile.lock
+++ b/ruby-2.6/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (9.5.0)
+    autoprefixer-rails (9.5.1)
       execjs
     aws-eventstream (1.0.2)
     aws-sdk (2.11.256)
@@ -349,7 +349,7 @@ GEM
     rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-its (1.2.0)
+    rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
     rspec-mocks (3.8.0)

--- a/ruby-2.6/Gemfile.lock
+++ b/ruby-2.6/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    kitchen-terraform (4.4.0)
+    kitchen-terraform (4.5.0)
       dry-types (~> 0.14.0)
       dry-validation (= 0.13.0)
       inspec (~> 3.0)

--- a/spec/lib/kitchen/terraform/debug_logger_spec.rb
+++ b/spec/lib/kitchen/terraform/debug_logger_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Copyright 2016 New Context Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen"
+require "kitchen/terraform/debug_logger"
+
+::RSpec.describe ::Kitchen::Terraform::DebugLogger do
+  subject do 
+    described_class.new logger
+  end
+
+  let :logger do 
+    instance_double ::Kitchen::Logger 
+  end
+
+  shared_examples "#debug" do
+    after do 
+      subject << "message" 
+    end
+
+    specify "forwards the message to #debug of the wrapped logger" do 
+      expect(logger).to receive(:debug).with "message" 
+    end
+  end
+
+  describe "#<< " do 
+    it_behaves_like "#debug" 
+  end
+
+  describe "#debug" do 
+    it_behaves_like "#debug" 
+  end
+end

--- a/spec/lib/kitchen/terraform/version_spec.rb
+++ b/spec/lib/kitchen/terraform/version_spec.rb
@@ -24,7 +24,7 @@ require "rubygems"
   end
 
   let :version do
-    ::Gem::Version.new "4.4.0"
+    ::Gem::Version.new "4.5.0"
   end
 
   describe ".assign_plugin_version" do

--- a/spec/support/kitchen/terraform/configurable_examples.rb
+++ b/spec/support/kitchen/terraform/configurable_examples.rb
@@ -34,7 +34,7 @@ require "kitchen/driver/terraform"
     end
 
     it "equals the gem version" do
-      expect(subject.instance_variable_get(:@plugin_version)).to eq "4.4.0"
+      expect(subject.instance_variable_get(:@plugin_version)).to eq "4.5.0"
     end
   end
 

--- a/test/terraform/attributes/outputs.tf
+++ b/test/terraform/attributes/outputs.tf
@@ -3,7 +3,8 @@ output "first_output" {
 }
 
 output "second_output" {
-  value = "Second Output"
+  value     = "Second Output"
+  sensitive = true
 }
 
 output "third_output" {


### PR DESCRIPTION
This branch fixes #318. 