### PR TITLE
Remove default values from unsupported base plugin attributes

### DIFF
--- a/lib/kitchen/provisioner/terraform.rb
+++ b/lib/kitchen/provisioner/terraform.rb
@@ -80,6 +80,22 @@ end
 #   kitchen converge default-ubuntu
 # @version 2
 class ::Kitchen::Provisioner::Terraform < ::Kitchen::Provisioner::Base
+  UNSUPPORTED_BASE_ATTRIBUTES = [
+    :command_prefix,
+    :downloads,
+    :http_proxy,
+    :https_proxy,
+    :ftp_proxy,
+    :max_retries,
+    :root_path,
+    :retry_on_exit_code,
+    :sudo,
+    :sudo_command,
+    :wait_for_retry,
+  ]
+  defaults.delete_if do |key|
+    UNSUPPORTED_BASE_ATTRIBUTES.include? key
+  end
   kitchen_provisioner_api_version 2
 
   include ::Kitchen::Terraform::Configurable

--- a/lib/kitchen/verifier/terraform.rb
+++ b/lib/kitchen/verifier/terraform.rb
@@ -70,14 +70,12 @@ module Kitchen
     #
     # This class implements the interface of Kitchen::Configurable which requires the following Reek suppressions:
     # :reek:MissingSafeMethod { exclude: [ finalize_config!, load_needed_dependencies! ] }
-    class Terraform
-      include ::Kitchen::Configurable
-      include ::Kitchen::Logging
+    class Terraform < ::Kitchen::Verifier::Base
       include ::Kitchen::Terraform::ConfigAttribute::Color
       include ::Kitchen::Terraform::ConfigAttribute::FailFast
       include ::Kitchen::Terraform::ConfigAttribute::Systems
       include ::Kitchen::Terraform::Configurable
-      @api_version = 2
+      kitchen_verifier_api_version 2
 
       attr_reader :inputs, :outputs
 

--- a/lib/kitchen/verifier/terraform.rb
+++ b/lib/kitchen/verifier/terraform.rb
@@ -71,6 +71,19 @@ module Kitchen
     # This class implements the interface of Kitchen::Configurable which requires the following Reek suppressions:
     # :reek:MissingSafeMethod { exclude: [ finalize_config!, load_needed_dependencies! ] }
     class Terraform < ::Kitchen::Verifier::Base
+      UNSUPPORTED_BASE_ATTRIBUTES = [
+        :chef_omnibus_root,
+        :command_prefix,
+        :http_proxy,
+        :https_proxy,
+        :ftp_proxy,
+        :root_path,
+        :sudo,
+        :sudo_command,
+      ]
+      defaults.delete_if do |key|
+        UNSUPPORTED_BASE_ATTRIBUTES.include? key
+      end
       include ::Kitchen::Terraform::ConfigAttribute::Color
       include ::Kitchen::Terraform::ConfigAttribute::FailFast
       include ::Kitchen::Terraform::ConfigAttribute::Systems


### PR DESCRIPTION
This branch removes the default values of unsupported base plugin attributes from `Provisioner/Terraform` and `Verifier/Terraform`. These default attributes were the motivation for `Verifier/Terraform` to not inherit from `Verifier/Base`, so that inheritance has been consequently added.