### PR TITLE
fix comment to match behavior

### DIFF
--- a/lib/kitchen/terraform/verify_version.rb
+++ b/lib/kitchen/terraform/verify_version.rb
@@ -21,7 +21,7 @@ require "rubygems"
 
 # Verifies that the output of the Terraform version command indicates a supported version of Terraform.
 #
-# Supported:: Terraform version >= 0.11.4, < 0.12.0.
+# Supported:: Terraform version >= 0.11.4, < 0.13.0.
 module ::Kitchen::Terraform::VerifyVersion
   class << self
     # Runs the function.


### PR DESCRIPTION
the comment does not match the actual behavior (which checks for the range `">= 0.11.4", "< 0.13.0"`).