### PR TITLE
Limit deploy stage to master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ jobs:
         directories:
           - ./vendor/bundle
     - stage: Deploy to RubyGems
-      if: branch = master
+      if: type != pull_request AND branch = master AND tag IS present
       dist: xenial
       language: ruby
       rvm: 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,7 @@ jobs:
         directories:
           - ./vendor/bundle
     - stage: Deploy to RubyGems
+      if: branch = master
       dist: xenial
       language: ruby
       rvm: 2.5.3


### PR DESCRIPTION
#398 highlighted that the deploy job should be completely skipped during pull request builds.