### PR TITLE
Remove branch check from release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
         version: 2.6.x
 
     - name: Build
-      if: github.event.base_ref == 'refs/heads/master'
       run: |
         printf -- "${GEM_PRIVATE_KEY}\n" > $HOME/certs/gem-private_key.pem
         gem cert --add certs/gem-public_cert.pem
@@ -27,7 +26,6 @@ jobs:
         GEM_PRIVATE_KEY: ${{ secrets.GEM_PRIVATE_KEY }}
 
     - name: Publish
-      if: github.event.base_ref == 'refs/heads/master'
       run: |
         RELEASE_VERSION=${GITHUB_REF#refs/tags/v}
         gem push kitchen-terraform-${RELEASE_VERSION}.gem


### PR DESCRIPTION
Was not working properly and not needed as job will run against master branch. Also only admins can push to this repo.