### PR TITLE
Upgrade gem command to use env variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
     - name: Publish
       run: |
+        gem update --system
         RELEASE_VERSION=${GITHUB_REF#refs/tags/v}
         gem push kitchen-terraform-${RELEASE_VERSION}.gem
       env:


### PR DESCRIPTION
v3.0.3 is not using GEM_HOST_API_KEY so upgrade newer version
https://github.com/rubygems/rubygems/issues/2829