### PR TITLE
Work around Thor namespace error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   test_ubun_ruby_2_5:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage/
 doc/
 examples/*/Gemfile.lock
 examples/*/test/assets
+gems.locked
 rubygems/credentials
 terraform_*/
 terraform.tfstate.d/

--- a/bin/update-gems-locked.sh
+++ b/bin/update-gems-locked.sh
@@ -12,6 +12,7 @@ do
   fi
   ruby --version
   set -x
+  gem install bundler
   if [ -e gems.locked ]
   then
     bundle update --all

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -57,7 +57,7 @@ end
   specification.add_runtime_dependency "delegate", "~> 0.1.0"
   specification.add_runtime_dependency "dry-validation", "~> 0.13"
   specification.add_runtime_dependency "mixlib-shellout", "~> 3.0"
-  specification.add_runtime_dependency "inspec", ">= 3", "< 5"
+  specification.add_runtime_dependency "inspec", ">= 3", "< 4.24.23"
   specification.add_runtime_dependency "json", "~> 2.2"
   specification.add_runtime_dependency "test-kitchen", "~> 2.1"
   specification.add_runtime_dependency "tty-which", "~> 0.4.0"

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -57,7 +57,7 @@ end
   specification.add_runtime_dependency "delegate", "~> 0.1.0"
   specification.add_runtime_dependency "dry-validation", "~> 0.13"
   specification.add_runtime_dependency "mixlib-shellout", "~> 3.0"
-  specification.add_runtime_dependency "inspec", ">= 3", "< 4.24.23"
+  specification.add_runtime_dependency "inspec", ">= 3", "< 5", "!= 4.24.26", "!= 4.24.28", "!= 4.24.32"
   specification.add_runtime_dependency "json", "~> 2.3"
   specification.add_runtime_dependency "test-kitchen", "~> 2.1"
   specification.add_runtime_dependency "tty-which", "~> 0.4.0"

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -58,7 +58,7 @@ end
   specification.add_runtime_dependency "dry-validation", "~> 0.13"
   specification.add_runtime_dependency "mixlib-shellout", "~> 3.0"
   specification.add_runtime_dependency "inspec", ">= 3", "< 4.24.23"
-  specification.add_runtime_dependency "json", "~> 2.2"
+  specification.add_runtime_dependency "json", "~> 2.3"
   specification.add_runtime_dependency "test-kitchen", "~> 2.1"
   specification.add_runtime_dependency "tty-which", "~> 0.4.0"
   specification.cert_chain = ["certs/gem-public_cert.pem"]

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -45,11 +45,11 @@ require "support/kitchen/terraform/configurable_examples"
   let :kitchen_instance do
     ::Kitchen::Instance.new(
       driver: subject,
-      lifecycle_hooks: ::Kitchen::LifecycleHooks.new(config),
+      lifecycle_hooks: ::Kitchen::LifecycleHooks.new(config, state_file),
       logger: ::Kitchen::Logger.new,
       platform: ::Kitchen::Platform.new(name: "test-platform"),
       provisioner: ::Kitchen::Provisioner::Base.new,
-      state_file: ::Kitchen::StateFile.new("/kitchen", "test-suite-test-platform"),
+      state_file: state_file,
       suite: ::Kitchen::Suite.new(name: "test-suite"),
       transport: ::Kitchen::Transport::Base.new,
       verifier: ::Kitchen::Verifier::Base.new,
@@ -58,6 +58,10 @@ require "support/kitchen/terraform/configurable_examples"
 
   let :state do
     {}
+  end
+
+  let :state_file do
+    ::Kitchen::StateFile.new "/kitchen", "test-suite-test-platform"
   end
 
   let :version_requirement do

--- a/spec/lib/kitchen/provisioner/terraform_spec.rb
+++ b/spec/lib/kitchen/provisioner/terraform_spec.rb
@@ -45,11 +45,11 @@ require "support/kitchen/terraform/configurable_examples"
   let :kitchen_instance do
     ::Kitchen::Instance.new(
       driver: driver,
-      lifecycle_hooks: ::Kitchen::LifecycleHooks.new(config),
+      lifecycle_hooks: ::Kitchen::LifecycleHooks.new(config, state_file),
       logger: kitchen_logger,
       platform: ::Kitchen::Platform.new(name: "test-platform"),
       provisioner: subject,
-      state_file: ::Kitchen::StateFile.new("/kitchen", "test-suite-test-platform"),
+      state_file: state_file,
       suite: ::Kitchen::Suite.new(name: "test-suite"),
       transport: ::Kitchen::Transport::Base.new,
       verifier: ::Kitchen::Verifier::Base.new,
@@ -58,6 +58,10 @@ require "support/kitchen/terraform/configurable_examples"
 
   let :kitchen_logger do
     ::Kitchen::Logger.new
+  end
+
+  let :state_file do
+    ::Kitchen::StateFile.new "/kitchen", "test-suite-test-platform"
   end
 
   before do

--- a/spec/lib/kitchen/verifier/terraform_spec.rb
+++ b/spec/lib/kitchen/verifier/terraform_spec.rb
@@ -85,11 +85,11 @@ require "support/kitchen/terraform/configurable_examples"
   let :kitchen_instance do
     ::Kitchen::Instance.new(
       driver: ::Kitchen::Driver::Base.new,
-      lifecycle_hooks: ::Kitchen::LifecycleHooks.new(config),
+      lifecycle_hooks: ::Kitchen::LifecycleHooks.new(config, state_file),
       logger: logger,
       platform: ::Kitchen::Platform.new(name: "test-platform"),
       provisioner: ::Kitchen::Provisioner::Base.new,
-      state_file: ::Kitchen::StateFile.new("/kitchen", "test-suite-test-platform"),
+      state_file: state_file,
       suite: ::Kitchen::Suite.new(name: "test-suite"),
       transport: ::Kitchen::Transport::Base.new,
       verifier: ::Kitchen::Verifier::Base.new,
@@ -98,6 +98,10 @@ require "support/kitchen/terraform/configurable_examples"
 
   let :logger do
     ::Kitchen::Logger.new
+  end
+
+  let :state_file do
+    ::Kitchen::StateFile.new("/kitchen", "test-suite-test-platform")
   end
 
   it_behaves_like "Kitchen::Terraform::ConfigAttribute::Color"


### PR DESCRIPTION
As detailed in https://github.com/inspec/inspec/issues/5387, inspec as of 4.24.23 modified how thor is required which broke it (at least for our use case).