### PR TITLE
Update release job to use different GitHub action for setting up Ruby

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        version: 2.6.x
+        ruby-version: 2.6 # uses the latest release matching that version (e.g., 2.6.6)
+        bundler-cache: false # when true, runs 'bundle install' and caches installed gems automatically
 
     - name: Build
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
-    - uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6 # uses the latest release matching that version (e.g., 2.6.6)
         bundler-cache: false # when true, runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
[actions/setup-ruby@v1](https://github.com/actions/setup-ruby) is deprecated with suggestion to use [ruby/setup-ruby@v1 ](https://github.com/ruby/setup-ruby)instead
