### PR TITLE
fix plugin loading for reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ terraform.tfstate.d/
 test/terraform/Plug Ins/Plug In Directory/
 tmp/
 vendor/
+test/reports/

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -26,6 +26,11 @@ suites:
           backend: local
           controls:
             - default
+          reporter:
+            - cli
+            - json:test/reports/inspec/default-attributes.json
+            - junit:test/reports/inspec/default-attributes.junit.xml
+            - junit2:test/reports/inspec/default-attributes.junit2.xml
         - name: attrs_outputs
           backend: local
           attrs_outputs:
@@ -42,11 +47,6 @@ suites:
             output_third_output: first_output
           controls:
             - precedence
-          reporter:
-            - cli
-            - json:test/reports/inspec/attributes.json
-            - junit:test/reports/inspec/attributes.junit.xml
-            - junit2:test/reports/inspec/attributes.junit2.xml
   - name: backend-ssh
     excludes:
       - osx

--- a/lib/kitchen/terraform/inspec_runner.rb
+++ b/lib/kitchen/terraform/inspec_runner.rb
@@ -60,11 +60,12 @@ module Kitchen
         self.host = options.fetch :host do
           ""
         end
-        self.runner = ::Inspec::Runner.new options.merge logger: ::Inspec::Log.logger
 
         v2_loader = ::Inspec::Plugin::V2::Loader.new
         v2_loader.load_all
         v2_loader.exit_on_load_error
+
+        self.runner = ::Inspec::Runner.new options.merge logger: ::Inspec::Log.logger
 
         profile_locations.each do |profile_location|
           runner.add_target profile_location


### PR DESCRIPTION
Plugins have to be loaded slightly earlier so that those are available when the inspec instance is created.