### PR TITLE
drop ENV TF_WARN_OUTPUT_ERRORS, so that errors are raised.

### DIFF
--- a/lib/kitchen/terraform/driver/destroy.rb
+++ b/lib/kitchen/terraform/driver/destroy.rb
@@ -77,6 +77,9 @@ module Kitchen
           )
           self.logger = logger
           self.options = { cwd: config.fetch(:root_module_directory), timeout: config.fetch(:command_timeout) }
+          self.destroy_options = options.merge(
+            environment: { "LC_ALL" => nil, "TF_IN_AUTOMATION" => "true", "TF_WARN_OUTPUT_ERRORS" => "true" }
+          )
           self.workspace_name = workspace_name
           self.destroy = ::Kitchen::Terraform::Command::Destroy.new config: config
           self.init = ::Kitchen::Terraform::Command::Init.new config: hash_config
@@ -100,6 +103,7 @@ module Kitchen
         attr_accessor(
           :command_executor,
           :destroy,
+          :destroy_options,
           :init,
           :logger,
           :options,
@@ -121,7 +125,7 @@ module Kitchen
 
         def destroy_infrastructure
           logger.warn "Destroying the Terraform-managed infrastructure..."
-          command_executor.run command: destroy, options: options do |standard_output:|
+          command_executor.run command: destroy, options: destroy_options do |standard_output:|
           end
           logger.warn "Finished destroying the Terraform-managed infrastructure."
         end

--- a/lib/kitchen/terraform/driver/destroy.rb
+++ b/lib/kitchen/terraform/driver/destroy.rb
@@ -76,10 +76,7 @@ module Kitchen
             logger: logger,
           )
           self.logger = logger
-          self.options = { cwd: config.fetch(:root_module_directory), timeout: config.fetch(:command_timeout) }
-          self.destroy_options = options.merge(
-            environment: { "LC_ALL" => nil, "TF_IN_AUTOMATION" => "true", "TF_WARN_OUTPUT_ERRORS" => "true" }
-          )
+          define_options config: config
           self.workspace_name = workspace_name
           self.destroy = ::Kitchen::Terraform::Command::Destroy.new config: config
           self.init = ::Kitchen::Terraform::Command::Init.new config: hash_config
@@ -121,6 +118,13 @@ module Kitchen
           command_executor.run command: workspace_new_test, options: options do |standard_output:|
           end
           logger.warn "Finished creating the #{workspace_name} Terraform workspace."
+        end
+
+        def define_options(config:)
+          self.options = { cwd: config.fetch(:root_module_directory), timeout: config.fetch(:command_timeout) }
+          self.destroy_options = options.merge(
+            environment: { "LC_ALL" => nil, "TF_IN_AUTOMATION" => "true", "TF_WARN_OUTPUT_ERRORS" => "true" }
+          )
         end
 
         def destroy_infrastructure

--- a/lib/kitchen/terraform/inspec_runner.rb
+++ b/lib/kitchen/terraform/inspec_runner.rb
@@ -61,10 +61,11 @@ module Kitchen
           ""
         end
 
-        v2_loader = ::Inspec::Plugin::V2::Loader.new
-        v2_loader.load_all
-        v2_loader.exit_on_load_error
-
+        ::Inspec::Plugin::V2::Loader.new.tap do |loader|
+          loader.load_all
+          loader.exit_on_load_error
+        end
+        
         self.runner = ::Inspec::Runner.new options.merge logger: ::Inspec::Log.logger
 
         profile_locations.each do |profile_location|

--- a/lib/kitchen/terraform/shell_out.rb
+++ b/lib/kitchen/terraform/shell_out.rb
@@ -29,16 +29,17 @@ module Kitchen
       #
       # @param command [String] the command to run.
       # @param logger [Kitchen::Logger] a logger for logging messages.
+      # @param options [Hash] options which adjust the execution of the command.
       # @return [Kitchen::Terraform::CommandExecutor]
       def initialize(command:, logger:, options:)
         self.command = command
         self.logger = logger
         self.shell_out = ::Mixlib::ShellOut.new(
           command,
-          options.merge(
+          {
             environment: { "LC_ALL" => nil, "TF_IN_AUTOMATION" => "true" },
             live_stream: logger,
-          )
+          }.merge(options)
         )
       end
 

--- a/lib/kitchen/terraform/shell_out.rb
+++ b/lib/kitchen/terraform/shell_out.rb
@@ -36,7 +36,7 @@ module Kitchen
         self.shell_out = ::Mixlib::ShellOut.new(
           command,
           options.merge(
-            environment: { "LC_ALL" => nil, "TF_IN_AUTOMATION" => "true", "TF_WARN_OUTPUT_ERRORS" => "1" },
+            environment: { "LC_ALL" => nil, "TF_IN_AUTOMATION" => "true" },
             live_stream: logger,
           )
         )

--- a/spec/lib/kitchen/terraform/driver/destroy_spec.rb
+++ b/spec/lib/kitchen/terraform/driver/destroy_spec.rb
@@ -96,6 +96,14 @@ require "rubygems"
   end
 
   describe "#call" do
+    let :destroy_options do
+      {
+        cwd: root_module_directory,
+        environment: { "LC_ALL" => nil, "TF_IN_AUTOMATION" => "true", "TF_WARN_OUTPUT_ERRORS" => "true" },
+        timeout: command_timeout
+      }
+    end
+
     let :options do
       { cwd: root_module_directory, timeout: command_timeout }
     end
@@ -123,7 +131,7 @@ require "rubygems"
         )
         expect(command_executor).to receive(:run).with(
           command: kind_of(::Kitchen::Terraform::Command::Destroy),
-          options: options,
+          options: destroy_options,
         ).ordered
         expect(command_executor).to receive(:run).with(
           command: kind_of(::Kitchen::Terraform::Command::WorkspaceSelect),
@@ -176,7 +184,7 @@ require "rubygems"
         ).ordered
         expect(command_executor).to receive(:run).with(
           command: kind_of(::Kitchen::Terraform::Command::Destroy),
-          options: options,
+          options: destroy_options,
         ).ordered
         expect(command_executor).to receive(:run).with(
           command: kind_of(::Kitchen::Terraform::Command::WorkspaceSelect),

--- a/spec/lib/kitchen/terraform/inspec_runner_spec.rb
+++ b/spec/lib/kitchen/terraform/inspec_runner_spec.rb
@@ -46,6 +46,10 @@ require "kitchen/terraform/inspec_runner"
       { key: "value", logger: logger }
     end
 
+    let :loader do
+      instance_double ::Inspec::Plugin::V2::Loader
+    end
+
     let :options do
       { key: "value" }
     end
@@ -59,6 +63,9 @@ require "kitchen/terraform/inspec_runner"
     end
 
     before do
+      allow(::Inspec::Plugin::V2::Loader).to receive(:new).and_return loader
+      allow(loader).to receive :load_all
+      allow(loader).to receive :exit_on_load_error
       allow(::Inspec::Runner).to receive(:new).with(full_options).and_return runner
       allow(runner).to receive(:add_target).with profile_location
       described_class.logger = logger

--- a/spec/lib/kitchen/terraform/shell_out_spec.rb
+++ b/spec/lib/kitchen/terraform/shell_out_spec.rb
@@ -39,7 +39,7 @@ require "mixlib/shellout"
     allow(::Mixlib::ShellOut).to receive(:new).with(
       command,
       {
-        environment: { "LC_ALL" => nil, "TF_IN_AUTOMATION" => "true", "TF_WARN_OUTPUT_ERRORS" => "1" },
+        environment: { "LC_ALL" => nil, "TF_IN_AUTOMATION" => "true" },
         live_stream: logger,
         option_key: "option_value",
       }


### PR DESCRIPTION
resolves https://github.com/newcontext-oss/kitchen-terraform/issues/440