### PR TITLE
Sets the default pwsh error action preference to stop for setup bundler action

### DIFF
--- a/.github/actions/setup-bundler-for-testing-win/setup-bundler-for-testing.ps1
+++ b/.github/actions/setup-bundler-for-testing-win/setup-bundler-for-testing.ps1
@@ -1,3 +1,4 @@
+$errorActionPreference="Stop"
 gem install bundler --conservative --minimal-deps --no-document --version="~>2.0"
 $GEMFILEDIR = $Env:GEMFILE_DIR
 bundle config --local gemfile "${GEMFILEDIR}/gems.rb"


### PR DESCRIPTION
This is the first part of fix for #437 forcing the actual failure in a pwsh step.