### PR TITLE
Updates the command to execute unit test to test:rspec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ The following command will execute the unit tests.
 > Executing unit tests with RSpec
 
 ```sh
-bundle exec rake test:spec
+bundle exec rake test:rspec
 ```
 
 [.rspec](.rspec) contains command line options which will be


### PR DESCRIPTION
During setup of local development env to address an issue it was found that the CONTRIBUTING.md file had an older reference on how to execute unit tests, should be test:rspec.