### PR TITLE
Fixes truly trapping the bundle install error in pwsh script and failing

### DIFF
--- a/.github/actions/setup-bundler-for-testing-win/setup-bundler-for-testing.ps1
+++ b/.github/actions/setup-bundler-for-testing-win/setup-bundler-for-testing.ps1
@@ -1,4 +1,4 @@
-gem install bundler --conservative --minimal-deps --no-document --version="~>2.0"
+gem install bundler --conservative --minimal-deps --no-document --version=`"~>2.0`"
 if (! $?) {
     Write-Error "Failed installing bundler"
     exit 1

--- a/.github/actions/setup-bundler-for-testing-win/setup-bundler-for-testing.ps1
+++ b/.github/actions/setup-bundler-for-testing-win/setup-bundler-for-testing.ps1
@@ -1,5 +1,8 @@
-$errorActionPreference="Stop"
 gem install bundler --conservative --minimal-deps --no-document --version="~>2.0"
+if (! $?) {
+    Write-Error "Failed installing bundler"
+    exit 1
+}
 $GEMFILEDIR = $Env:GEMFILE_DIR
 bundle config --local gemfile "${GEMFILEDIR}/gems.rb"
 bundle config --local jobs $(nproc --ignore=1)


### PR DESCRIPTION
So, there is a weird symbiotic relationship between running a Windows command and it is failing within a pwsh script AND not failing the WHOLE darn pwsh script. Therefore, we explicitly check for error after executing gem install bundler and then force exit the script if error.

This darn well should catch the failing command and the step should fail. But will still need to address the actual error in the script, which I do know how to fix it.