### PR TITLE
Drop path from download-artifact

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -92,7 +92,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ruby-gem
-          path: kitchen-terraform.gem
       - name: Install Ruby Gems
         run: gem install --conservative --minimal-deps --verbose kitchen-terraform.gem rake
       - name: Setup Terraform


### PR DESCRIPTION
The path creates a subdirectory to host the artifact.