### PR TITLE
Drop Ruby 2.6 and Fix Transport Bugs

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
@@ -63,7 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
   - `command_timeout`
   - `root_module_directory`
 - Dropped support for Inspec < 4.25.1
+- Dropped support for Ruby 2.6 which reach end of life on 2022-04-12.
 
 ## [6.1.0] - 2022-01-22
 

--- a/gems.rb
+++ b/gems.rb
@@ -16,6 +16,6 @@
 
 source "https://rubygems.org/"
 
-ruby ">= 2.6"
+ruby ">= 2.7"
 
 gemspec

--- a/kitchen-terraform.gemspec
+++ b/kitchen-terraform.gemspec
@@ -44,7 +44,7 @@ require "rubygems"
   specification.add_runtime_dependency "test-kitchen", ">= 2.1", "< 4.0"
   specification.add_runtime_dependency "tty-which", "~> 0.5.0"
   specification.cert_chain = ["certs/gem-public_cert.pem"]
-  specification.required_ruby_version = [">= 2.6", "< 4.0"]
+  specification.required_ruby_version = [">= 2.7", "< 4.0"]
   specification.requirements = ["Terraform >= v0.11.4, < v2.0.0"]
   specification.signing_key = "certs/gem-private_key.pem" if $PROGRAM_NAME =~ /gem\z/
 end

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -152,15 +152,12 @@ module Kitchen
       include ::Kitchen::Terraform::ConfigAttribute::BackendConfigurations
 
       include ::Kitchen::Terraform::ConfigAttribute::Client
-      deprecate_config_for :client, "driver.client is deprecated; use transport.client instead"
+      deprecate_config_for :client, "use transport.client instead"
 
       include ::Kitchen::Terraform::ConfigAttribute::Color
 
       include ::Kitchen::Terraform::ConfigAttribute::CommandTimeout
-      deprecate_config_for(
-        :command_timeout,
-        "driver.command_timeout is deprecated; use transport.command_timeout instead"
-      )
+      deprecate_config_for :command_timeout, "use transport.command_timeout instead"
 
       include ::Kitchen::Terraform::ConfigAttribute::Lock
 
@@ -171,10 +168,7 @@ module Kitchen
       include ::Kitchen::Terraform::ConfigAttribute::PluginDirectory
 
       include ::Kitchen::Terraform::ConfigAttribute::RootModuleDirectory
-      deprecate_config_for(
-        :root_module_directory,
-        "driver.root_module_directory is deprecated; use transport.root_module_directory instead"
-      )
+      deprecate_config_for :root_module_directory, "use transport.root_module_directory instead"
 
       include ::Kitchen::Terraform::ConfigAttribute::VariableFiles
 

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -272,8 +272,8 @@ module Kitchen
 
       private
 
-      attr_accessor :action_failed
-      attr_writer :deprecated_config, :transport
+      attr_accessor :action_failed, :deprecated_config
+      attr_writer :transport
     end
   end
 end

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -248,6 +248,8 @@ module Kitchen
       def finalize_config!(instance)
         super
 
+        self.deprecated_config ||= {}
+
         transport = instance.transport
 
         self.transport = if ::Kitchen::Transport::Terraform == transport.class
@@ -271,7 +273,7 @@ module Kitchen
       private
 
       attr_accessor :action_failed
-      attr_writer :transport
+      attr_writer :deprecated_config, :transport
     end
   end
 end

--- a/lib/kitchen/terraform/transport/connection.rb
+++ b/lib/kitchen/terraform/transport/connection.rb
@@ -54,7 +54,7 @@ module Kitchen
 
           self.client = options.delete :client
           self.command_timeout = options.delete :command_timeout
-          self.environment = options.delete(:environment) or {}
+          self.environment = options.delete(:environment) || {}
           self.root_module_directory = options.delete :root_module_directory
         end
       end


### PR DESCRIPTION
This PR drops support for EOL Ruby 2.6 and fixes some bugs introduced by #500.