### PR TITLE
Reintroduce Support for Concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
 - Dropped support for Ruby 2.7 which reached end of life on 2023-03-31.
 - Dropped support for InSpec 4.X which reached end of life on some
   indeterminate date.
+- Support for concurrency with the following commands was reintroduced:
+  `create`; `converge`; `setup`; `destroy`. Be safe and test quickly!
 
 ## [6.1.0] - 2022-01-22
 

--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -142,13 +142,6 @@ module Kitchen
     class Terraform < ::Kitchen::Driver::Base
       kitchen_driver_api_version 2
 
-      no_parallel_for(
-        :create,
-        :converge,
-        :setup,
-        :destroy
-      )
-
       include ::Kitchen::Terraform::ConfigAttribute::BackendConfigurations
 
       include ::Kitchen::Terraform::ConfigAttribute::Client

--- a/spec/lib/kitchen/driver/terraform_spec.rb
+++ b/spec/lib/kitchen/driver/terraform_spec.rb
@@ -101,12 +101,6 @@ require "support/kitchen/terraform/configurable_examples"
 
   it_behaves_like "Kitchen::Terraform::Configurable"
 
-  describe ".serial_actions" do
-    specify "actions are returned" do
-      expect(described_class.serial_actions).to contain_exactly(:create, :converge, :setup, :destroy)
-    end
-  end
-
   describe "#create" do
     let :create do
       instance_double ::Kitchen::Terraform::Driver::Create


### PR DESCRIPTION
This PR reintroduces support for concurrency. There is still no safety mechanism around running concurrent Kitchen instances which share a root module directory ⚠️ 