### PR TITLE
Fix client doctor path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- The doctor check for the `client` attribute uses the PATH to validate
+  the value.
+
 ## [7.0.0] - 2023-04-09
 
 ### Added

--- a/lib/kitchen/terraform/config_attribute/client.rb
+++ b/lib/kitchen/terraform/config_attribute/client.rb
@@ -75,13 +75,9 @@ module Kitchen
         def doctor_config_client
           errors = false
 
-          if !::File.exist? config_client
+          if !::TTY::Which.exist? config_client
             errors = true
-            logger.error "client '#{config_client}' does not exist"
-          end
-          if !::File.executable? config_client
-            errors = true
-            logger.error "client '#{config_client}' is not executable"
+            logger.error "client '#{config_client}' is not executable or does not exist"
           end
 
           errors

--- a/spec/lib/kitchen/transport/terraform_spec.rb
+++ b/spec/lib/kitchen/transport/terraform_spec.rb
@@ -73,6 +73,10 @@ require "support/kitchen/terraform/configurable_examples"
   end
 
   describe "#doctor" do
+    let :config do
+      {client: "/nonexistent/client"}
+    end
+
     specify "should return true" do
       subject.finalize_config! kitchen_instance
 

--- a/spec/support/kitchen/terraform/config_attribute/client_examples.rb
+++ b/spec/support/kitchen/terraform/config_attribute/client_examples.rb
@@ -91,7 +91,7 @@ require "tempfile"
         file = ::Tempfile.new ["client", ".exe"]
         file.chmod 0777
 
-        file
+        ::File.absolute_path file
       end
 
       specify "should return false" do


### PR DESCRIPTION
This PR fixes #520 by checking the PATH for the provided `client` value.