### PR TITLE
Fix Connection Logger Initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Transport connections no longer override provided loggers.
+
 ## [7.0.1] - 2023-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased][unreleased]
 
+## [7.0.2] - 2023-04-24
+
 ### Fixed
 
 - Transport connections no longer override provided loggers.
@@ -823,7 +825,8 @@ Free-As-In-Beer
 - Initial release
 
 [unreleased]:
-  https://github.com/newcontext/kitchen-terraform/compare/v7.0.1...HEAD
+  https://github.com/newcontext/kitchen-terraform/compare/v7.0.2...HEAD
+[7.0.2]: https://github.com/newcontext/kitchen-terraform/compare/v7.0.1...v7.0.2
 [7.0.1]: https://github.com/newcontext/kitchen-terraform/compare/v7.0.0...v7.0.1
 [7.0.0]: https://github.com/newcontext/kitchen-terraform/compare/v6.1.0...v7.0.0
 [6.1.0]: https://github.com/newcontext/kitchen-terraform/compare/v6.0.0...v6.1.0

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ example.
 ---
 
 ```sh
-gem install kitchen-terraform --version 7.0.1
+gem install kitchen-terraform --version 7.0.2
 ```
 
 ---

--- a/lib/kitchen/terraform/version.rb
+++ b/lib/kitchen/terraform/version.rb
@@ -71,7 +71,7 @@ module Kitchen
 
         # @api private
         def value
-          self.value = ::Gem::Version.new "7.0.1" if not @value
+          self.value = ::Gem::Version.new "7.0.2" if not @value
           @value
         end
 

--- a/lib/kitchen/transport/terraform.rb
+++ b/lib/kitchen/transport/terraform.rb
@@ -125,10 +125,9 @@ module Kitchen
       # @return [Hash] hash of connection options.
       # @api private
       def connection_options(data)
-        opts = super
+        opts = super.merge! data
 
-        opts.merge! data
-        opts.merge! logger: logger
+        opts.merge! logger: logger if !opts.key? :logger
 
         opts
       end

--- a/spec/lib/kitchen/terraform/version_spec.rb
+++ b/spec/lib/kitchen/terraform/version_spec.rb
@@ -24,7 +24,7 @@ require "rubygems"
   end
 
   let :version do
-    ::Gem::Version.new "7.0.1"
+    ::Gem::Version.new "7.0.2"
   end
 
   describe ".assign_plugin_version" do

--- a/spec/support/kitchen/terraform/configurable_examples.rb
+++ b/spec/support/kitchen/terraform/configurable_examples.rb
@@ -26,7 +26,7 @@ require "kitchen/driver/terraform"
 
   describe "@plugin_version" do
     it "equals the gem version" do
-      expect(described_class.instance_variable_get(:@plugin_version)).to eq "7.0.1"
+      expect(described_class.instance_variable_get(:@plugin_version)).to eq "7.0.2"
     end
   end
 


### PR DESCRIPTION
This PR fixes connection logger initialization to ensure provided loggers are not overridden by the transport logger.